### PR TITLE
#6 change to use master branch of splunk/splunk-ansible for a quick fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 IMAGE_VERSION ?= "latest"
 DOCKER_BUILD_FLAGS = 
 TEST_IMAGE_NAME = "spldocker"
-SPLUNK_ANSIBLE_BRANCH ?= the_next_century
+SPLUNK_ANSIBLE_BRANCH ?= master
 SPLUNK_COMPOSE ?= cluster_absolute_unit.yaml
 # Set Splunk version/build parameters here to define downstream URLs and file names
 SPLUNK_PRODUCT := splunk


### PR DESCRIPTION
Not sure if splunk/splunk-ansible will have a clean `master` branch for splunk/docker-splunk.
This will at least allow `make all` to be successful