### PR TITLE
Adding maintainer label for docker image certification

### DIFF
--- a/splunk/debian-9/Dockerfile
+++ b/splunk/debian-9/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM base-debian-9:latest
+LABEL maintainer="support@splunk.com"
 
 ARG SPLUNK_FILENAME
 ARG SPLUNK_BUILD_URL


### PR DESCRIPTION
Trying to resolve the following image certification errors from the tool [here](https://docs.docker.com/docker-store/certify-images/):
```
Warning: Docker image was not built using Docker Enterprise Edition!
Warning: Docker image metadata does not contain an Author or Maintainer!
Warning: Docker container 9ef5cdac5d2a420a566eb2f5d5a5e8671cc45d3b3ff3612e1b21b5f521d12d6e did not respond to the stop command in the allotted time of 60 seconds and had to be killed!
Warning: Docker container did not exit with an exit code of 0! Exit code was 137.
```

Of the above, the Docker EE will need to be done at build-time, and the stop-within-60s is addressed by running the inspect CLI tool with `--start-wait-time 120`. This PR address the author/maintainer warning.

Also not sure how we want to address the exit code? The default docker stop signal is SIGTERM which corresponds to the exit code, but I don't know if we should swallow that and return something friendlier just for the sake of this check?
