### PR TITLE
upgraded default version from 7.1.2 to 7.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ SPLUNK_ANSIBLE_BRANCH ?= master
 SPLUNK_COMPOSE ?= cluster_absolute_unit.yaml
 # Set Splunk version/build parameters here to define downstream URLs and file names
 SPLUNK_PRODUCT := splunk
-SPLUNK_VERSION := 7.1.2
-SPLUNK_BUILD := a0c72a66db66
+SPLUNK_VERSION := 7.2.0
+SPLUNK_BUILD := 8c86330ac18
 ifeq ($(shell arch), s390x)
 	SPLUNK_ARCH = s390x
 else

--- a/tests/test_debian_9.py
+++ b/tests/test_debian_9.py
@@ -37,8 +37,8 @@ BASE_IMAGE_NAME = "base-debian-9"
 SPLUNK_IMAGE_NAME = "splunk-debian-9"
 UF_IMAGE_NAME = "splunkforwarder-debian-9"
 # Splunk variables
-SPLUNK_VERSION = "7.1.2"
-SPLUNK_BUILD = "a0c72a66db66"
+SPLUNK_VERSION = "7.2.0"
+SPLUNK_BUILD = "8c86330ac18"
 SPLUNK_FILENAME = "splunk-{}-{}-Linux-x86_64.tgz".format(SPLUNK_VERSION, SPLUNK_BUILD)
 SPLUNK_BUILD_URL = "https://download.splunk.com/products/splunk/releases/{}/linux/{}".format(SPLUNK_VERSION, SPLUNK_FILENAME)
 UF_FILENAME = "splunkforwarder-{}-{}-Linux-x86_64.tgz".format(SPLUNK_VERSION, SPLUNK_BUILD)


### PR DESCRIPTION
Since 7.2.0 is released, we need to upgrade default version and hash used in Makefile and tests.