### PR TITLE
Task/emphasizing password requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Use the following command to start a single instance of Splunk Enterprise:
 Replace `"<password>"` with the initial password that you wish to use for logging into the Splunk admin
 user account. You can then access Splunk at http://localhost:8000 with those credentials.
 
-*Please note, the password supplied must conform to the default
-[Splunk Enterprise password requirements](https://docs.splunk.com/Documentation/Splunk/latest/Security/Configurepasswordsinspecfile)*
+**Please note, the password supplied must conform to the default
+[Splunk Enterprise password requirements](https://docs.splunk.com/Documentation/Splunk/latest/Security/Configurepasswordsinspecfile).**
 
 Notice that the license agreement has to be explicitly accepted. Splunk will not start
 unless you pass the argument `--accept-license` to every container.

--- a/splunk/debian-9/entrypoint.sh
+++ b/splunk/debian-9/entrypoint.sh
@@ -42,6 +42,7 @@ prep_ansible() {
 		ansible-playbook --version
 		python inventory/environ.py --write-to-file
 		cat /opt/ansible/inventory/ansible_inventory.json
+		cat /opt/ansible/inventory/messages.txt || true
 		echo
 	fi
 }


### PR DESCRIPTION
Added a default splunk password validation. There is another PR open against the Splunk Ansible repo to work with the changes in this repo. 