### PR TITLE
#22 make ansible should always pull in the latest from splunk-ansible repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ all: splunk uf
 ansible:
 	if [ -d "splunk-ansible" ]; then \
 		echo "Ansible directory exists - skipping clone"; \
+		(cd splunk-ansible; git pull ; git checkout ${SPLUNK_ANSIBLE_BRANCH} ) \
 	else \
 		git clone https://github.com/splunk/splunk-ansible.git --branch ${SPLUNK_ANSIBLE_BRANCH}; \
 	fi


### PR DESCRIPTION
This should keep the splunk-ansible repo up to date.

```
make ansible

if [ -d "splunk-ansible" ]; then \
		echo "Ansible directory exists - skipping clone"; \
		(cd splunk-ansible; git pull ; git checkout master ) \
	else \
		git clone https://github.com/splunk/splunk-ansible.git --branch master; \
	fi
Ansible directory exists - skipping clone
remote: Enumerating objects: 7, done.
remote: Counting objects: 100% (7/7), done.
remote: Compressing objects: 100% (1/1), done.
remote: Total 4 (delta 2), reused 4 (delta 2), pack-reused 0
Unpacking objects: 100% (4/4), done.
From https://github.com/splunk/splunk-ansible
 * [new branch]      task/emphasizing_password_requirement -> origin/task/emphasizing_password_requirement
Already up to date.
Already on 'master'
Your branch is up to date with 'origin/master'.
```