### PR TITLE
not exposing password via a ps -ax| grep SPLUNK_PASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ For more fine-grained control of which images to build, please refer to the `Mak
 
 Use the following command to start a single instance of Splunk Enterprise:
 ```
- $> docker run -it -p 8000:8000 -e 'SPLUNK_START_ARGS=--accept-license' -e 'SPLUNK_PASSWORD=<password>' splunk-debian-9:latest start
+ $> export SPLUNK_PASSWORD=<password>
+ $> docker run -it -p 8000:8000 -e 'SPLUNK_PASSWORD' -e 'SPLUNK_START_ARGS=--accept-license' splunk-debian-9:latest start
 ```
 Replace "<password>" with the initial password to wish use for logging into the Splunk admin
 user account. You can then access Splunk at http://localhost:8000 with those credentials.


### PR DESCRIPTION
In the original instructions with starting the container via -e 'SPLUNK_PASSWORD=<password>', any user on that system can see the password on the command line

This change will
1. Be slightly better reminding users that they need to set the password by moving -e 'SPLUNK_PASSWORD' to the front of the command line and adding a 2nd line to set the password
2. No longer exposing the password on the command line

This is the original, notice the password can be seen by anyone on the server
```
$ ps -ax| grep SPLUNK_PASSWORD

46153 ttys005    0:00.07 docker run -it -p 8001:8000 -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_PASSWORD=BA574F4C-F8CF-49AF-8919-F3C7A826B485 splunk-debian-9:latest start
```
This is a slightly better version, where the password is not on the env.  Anyone with docker access can still get into the container though.  But that is another story.

```
$ ps -ax| grep SPLUNK_PASSWORD
45815 ttys006    0:00.09 docker run -it -p 8000:8000 -e SPLUNK_PASSWORD -e SPLUNK_START_ARGS=--accept-license splunk-debian-9:latest start
```