### PR TITLE
Splunk upgrade cspl29

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ SPLUNK_ANSIBLE_BRANCH ?= master
 SPLUNK_COMPOSE ?= cluster_absolute_unit.yaml
 # Set Splunk version/build parameters here to define downstream URLs and file names
 SPLUNK_PRODUCT := splunk
-SPLUNK_VERSION := 7.2.0
-SPLUNK_BUILD := 8c86330ac18
+SPLUNK_VERSION := 7.2.1
+SPLUNK_BUILD := be11b2c46e23
 ifeq ($(shell arch), s390x)
 	SPLUNK_ARCH = s390x
 else

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -24,7 +24,7 @@ by passing in environment variables. Below is a list of environment variables th
 
 #### Valid Enterprise Environment Variables
 | Environment Variable Name | Description | Required for Standalone | Required for Search Head Clustering | Required for Index Clustering |
-|---|---|:---:|:---:|:---:|
+| --- | --- | --- | --- | --- |
 | SPLUNK_BUILD_URL | URL to Splunk build where we can fetch a Splunk build to install | no | no | no |
 | SPLUNK_DEFAULTS_URL | default.yml URL | no | no | no |
 | SPLUNK_UPGRADE | If this is True, we won’t run any provisioning after installation. Use this to upgrade and redeploy containers with a newer version of Splunk. | no | no | no |
@@ -35,7 +35,7 @@ by passing in environment variables. Below is a list of environment variables th
 | SPLUNK_STANDALONE_URL | List of all Splunk Enterprise standalone hosts (network alias) separated by comma | no | no | no |
 | SPLUNK_SEARCH_HEAD_URL | List of all Splunk Enterprise search head hosts (network alias) separated by comma | no | yes | yes |
 | SPLUNK_INDEXER_URL| List of all Splunk Enterprise indexer hosts (network alias) separated by comma | no | yes | yes |
-| SPLUNK_HEAVY_FORWARDER_URL | List of all Splunk Enterprise heavy forwarder hosts (network alias) separated by comma | no |  no | no |
+| SPLUNK_HEAVY_FORWARDER_URL | List of all Splunk Enterprise heavy forwarder hosts (network alias) separated by comma | no | no | no |
 | SPLUNK_DEPLOYER_URL | One Splunk Enterprise deployer host (network alias) | no | yes | no |
 | SPLUNK_CLUSTER_MASTER_URL | One Splunk Enterprise cluster master host (network alias) | no | no | yes |
 | SPLUNK_SEARCH_HEAD_CAPTAIN_URL | One Splunk Enterprise search head host (network alias). Passing this ENV variable will enable search head clustering. | no | yes | no |
@@ -50,8 +50,8 @@ by passing in environment variables. Below is a list of environment variables th
 * Password must be set either in default.yml or as the environment variable `SPLUNK_PASSWORD`
 
 #### Valid Universal Forwarder Environment Variables
-|Environment Variable Name| Description | Required for Standalone| Required for Search Head Clustering | Required for Index Clustering |
-|---|---|:---:|:---:|:---:|
+| Environment Variable Name | Description | Required for Standalone | Required for Search Head Clustering | Required for Index Clustering |
+| --- | --- | --- | --- | --- |
 | SPLUNK_DEPLOYMENT_SERVER | One Splunk host (network alias) that we use as a deployment server. (http://docs.Splunk.com/Documentation/Splunk/latest/Updating/Configuredeploymentclients) | no | no | no |
 | SPLUNK_ADD | List of items to add to monitoring separated by comma. Example, SPLUNK_ADD=udp 1514,monitor /var/log/*. This will monitor udp 1514 port and /var/log/* files. | no | no | no |
 | SPLUNK_BEFORE_START_CMD | List of commands to run before Splunk starts separated by comma. Ansible will run “{{splunk.exec}} {{item}}”. | no | no | no |
@@ -69,8 +69,8 @@ Example:
     retry_num: 100
 ```
 
-|Variable Name| Description | Parent Object | Default Value | Required for Standalone| Required for Search Head Clustering | Required for Index Clustering |
-|---|---|:---:|:---:|:---:|:---:|:---:|
+| Variable Name | Description | Parent Object | Default Value | Required for Standalone | Required for Search Head Clustering | Required for Index Clustering |
+| --- | --- | --- | --- | --- | --- | --- |
 | retry_num | Default number of loop attempts to connect containers | none | 100 | yes | yes | yes |
 
 The major object "splunk" in the YAML file will contain variables that influence how Splunk operates. Example:
@@ -94,22 +94,22 @@ The major object "splunk" in the YAML file will contain variables that influence
         hec_token: <default_hec_token>
 ```
 
-|Variable Name| Description | Parent Object | Default Value | Required for Standalone| Required for Search Head Clustering | Required for Index Clustering |
-|---|---|:---:|:---:|:---:|:---:|:---:|
-|opt| Parent directory where Splunk is running | splunk | /opt | yes | yes | yes |
-|home| Location of the Splunk Installation | splunk | /opt/splunk | yes | yes | yes |
-|user| Operating System User to Run Splunk Enterprise As | splunk | splunk | yes | yes | yes |
-|group| Operating System Group to Run Splunk Enterprise As | splunk | splunk | yes | yes | yes |
-|exec| Path to the Splunk Binary | splunk | /opt/splunk/bin/splunk | yes | yes | yes |
-|pid| Location to the Running PID File | splunk | /opt/splunk/var/run/splunk/splunkd.pid | yes | yes | yes
-|password| Password for the admin account | splunk | **none** | yes | yes | yes |
-|svc_port| Default Admin Port | splunk | 8089 | yes | yes | yes |
-|s2s_port| Default Forwarding Port | splunk | 9997 | yes | yes | yes |
-|http_port| Default SplunkWeb Port | splunk | 8000 | yes | yes | yes |
-|hec_port| Default HEC Input Port | splunk | 8088 | no | no | no |
-|hec_disabled| Enable / Disable HEC | splunk | 0 | no | no | no |
-|hec_enableSSL| Force HEC to use encryption | splunk | 1 | no | no | no |
-|hec_token| Token to enable for HEC inputs | splunk | **none** | no | no | no |
+| Variable Name | Description | Parent Object | Default Value | Required for Standalone | Required for Search Head Clustering | Required for Index Clustering |
+| --- | --- | --- | --- | --- | --- | --- |
+| opt | Parent directory where Splunk is running | splunk | /opt | yes | yes | yes |
+| home | Location of the Splunk Installation | splunk | /opt/splunk | yes | yes | yes |
+| user | Operating System User to Run Splunk Enterprise As | splunk | splunk | yes | yes | yes |
+| group | Operating System Group to Run Splunk Enterprise As | splunk | splunk | yes | yes | yes |
+| exec | Path to the Splunk Binary | splunk | /opt/splunk/bin/splunk | yes | yes | yes |
+| pid | Location to the Running PID File | splunk | /opt/splunk/var/run/splunk/splunkd.pid | yes | yes | yes
+| password | Password for the admin account | splunk | **none** | yes | yes | yes |
+| svc_port | Default Admin Port | splunk | 8089 | yes | yes | yes |
+| s2s_port | Default Forwarding Port | splunk | 9997 | yes | yes | yes |
+| http_port | Default SplunkWeb Port | splunk | 8000 | yes | yes | yes |
+| hec_port | Default HEC Input Port | splunk | 8088 | no | no | no |
+| hec_disabled | Enable / Disable HEC | splunk | 0 | no | no | no |
+| hec_enableSSL | Force HEC to use encryption | splunk | 1 | no | no | no |
+| hec_token | Token to enable for HEC inputs | splunk | **none** | no | no | no |
 
 The app_paths section is located as part of the "splunk" parent object. The settings located in this section will directly influence how apps are installed inside the container. Example:
 ```
@@ -120,12 +120,12 @@ The app_paths section is located as part of the "splunk" parent object. The sett
             httpinput: /opt/splunk/etc/apps/Splunk_httpinput
 ```
 
-|Variable Name| Description | Parent Object | Default Value | Required for Standalone| Required for Search Head Clustering | Required for Index Clustering |
-|---|---|:---:|:---:|:---:|:---:|:---:|
-|default| Normal apps for standalone instances will be installed in this location | splunk.app_paths | **none** | no | no | no |
-|shc| Apps for search head cluster instances will be installed in this location (usually only done on the deployer)| splunk.app_paths | **none** | no | no | no |
-|idxc| Apps for index cluster instances will be installed in this location (usually only done on the cluster master)| splunk.app_paths | **none** | no | no | no |
-|httpinput| App to use and configure when setting up HEC based instances.| splunk.app_paths | **none** | no | no | no |
+| Variable Name | Description | Parent Object | Default Value | Required for Standalone | Required for Search Head Clustering | Required for Index Clustering |
+| --- | --- | --- | --- | --- | --- | --- |
+| default | Normal apps for standalone instances will be installed in this location | splunk.app_paths | **none** | no | no | no |
+| shc | Apps for search head cluster instances will be installed in this location (usually only done on the deployer)| splunk.app_paths | **none** | no | no | no |
+| idxc | Apps for index cluster instances will be installed in this location (usually only done on the cluster master)| splunk.app_paths | **none** | no | no | no |
+| httpinput | App to use and configure when setting up HEC based instances.| splunk.app_paths | **none** | no | no | no |
 
 Search Head Clustering can be configured using the "shc" sub-object. Example:
 ```
@@ -136,12 +136,12 @@ Search Head Clustering can be configured using the "shc" sub-object. Example:
             replication_factor: 3
             replication_port: 4001
 ```
-|Variable Name| Description | Parent Object | Default Value | Required for Standalone| Required for Search Head Clustering | Required for Index Clustering |
-|---|---|:---:|:---:|:---:|:---:|:---:|
-|enable| Instructs the container to create a search head cluster | splunk.shc | false| no | yes | no |
-|secret| A secret phrase to use for all SHC communication and binding. Please note, once set this can not be changed without rebuilding the cluster. | splunk.shc | **none** | no | yes | no |
-|replication_factor| Consult docs.splunk.com for valid settings for your use case | splunk.shc | 3 | no | yes | no |
-|replication_port| Default port for the SHC to communicate on | splunk.shc | 4001| no | yes | no |
+| Variable Name | Description | Parent Object | Default Value | Required for Standalone | Required for Search Head Clustering | Required for Index Clustering |
+| --- | --- | --- | --- | --- | --- | --- |
+| enable | Instructs the container to create a search head cluster | splunk.shc | false | no | yes | no |
+| secret | A secret phrase to use for all SHC communication and binding. Please note, once set this can not be changed without rebuilding the cluster. | splunk.shc | **none** | no | yes | no |
+| replication_factor | Consult docs.splunk.com for valid settings for your use case | splunk.shc | 3 | no | yes | no |
+| replication_port | Default port for the SHC to communicate on | splunk.shc | 4001 | no | yes | no |
 
 Lastly, Index Clustering is configured with the `idxc` sub-object. Example:
 ```
@@ -152,8 +152,8 @@ Lastly, Index Clustering is configured with the `idxc` sub-object. Example:
             replication_factor: 3
             replication_port: 9887
 ```
-|Variable Name| Description | Parent Object | Default Value | Required for Standalone| Required for Search Head Clustering | Required for Index Clustering |
-|---|---|:---:|:---:|:---:|:---:|:---:|
+| Variable Name | Description | Parent Object | Default Value | Required for Standalone| Required for Search Head Clustering | Required for Index Clustering |
+| --- | --- | --- | --- | --- | --- | --- |
 | secret | Secret used for transmission between the cluster master and indexers | splunk.idxc | **none** | no | no | yes |
 | search_factor | Search factor to be used for search artifacts | splunk.idxc | 2 | no | no | yes |
 | replication_factor | Bucket replication factor used between index peers | splunk.idxc | 3 | no | no | yes |

--- a/test_scenarios/1so_namedvolumes_upgrade.yaml
+++ b/test_scenarios/1so_namedvolumes_upgrade.yaml
@@ -1,0 +1,28 @@
+version: "3.6"
+
+networks:
+  splunknet:
+    driver: bridge
+    attachable: true
+
+volumes:
+  so1-etc:
+  so1-var:
+
+services:
+  so1:
+    image: splunk/splunk:latest
+    hostname: so1
+    container_name: so1
+    environment:
+      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_PASSWORD
+      - DEBUG=true
+      - SPLUNK_UPGRADE=true
+    ports:
+      - 8000
+      - 8089
+    volumes:
+      - so1-etc:/opt/splunk/etc
+      - so1-var:/opt/splunk/var
+      

--- a/test_scenarios/3idx3sh1cm_upgrade.yaml
+++ b/test_scenarios/3idx3sh1cm_upgrade.yaml
@@ -4,7 +4,7 @@ networks:
   splunknet:
     driver: bridge
     attachable: true
-  
+
 volumes:
   so1-etc:
   so1-var:
@@ -28,6 +28,7 @@ services:
       - SPLUNK_LICENSE_URI
       - DEBUG=true
       - SPLUNK_PASSWORD
+      - SPLUNK_UPGRADE=true
     ports:
       - 8000
       - 8089
@@ -35,7 +36,6 @@ services:
       - ./defaults:/tmp/defaults
       - so1-etc:/opt/splunk/etc
       - so1-var:/opt/splunk/var
-      
 
   sh2:
     networks:
@@ -55,6 +55,7 @@ services:
       - SPLUNK_LICENSE_URI
       - DEBUG=true
       - SPLUNK_PASSWORD
+      - SPLUNK_UPGRADE=true
     ports:
       - 8000
       - 8089
@@ -81,6 +82,7 @@ services:
       - SPLUNK_LICENSE_URI
       - DEBUG=true
       - SPLUNK_PASSWORD
+      - SPLUNK_UPGRADE=true
     ports:
       - 8000
       - 8089
@@ -107,6 +109,7 @@ services:
       - SPLUNK_LICENSE_URI
       - DEBUG=true
       - SPLUNK_PASSWORD
+      - SPLUNK_UPGRADE=true
     ports:
       - 8000
       - 8089
@@ -133,6 +136,7 @@ services:
       - SPLUNK_LICENSE_URI
       - DEBUG=true
       - SPLUNK_PASSWORD
+      - SPLUNK_UPGRADE=true
     ports:
       - 8000
       - 8089
@@ -159,6 +163,7 @@ services:
       - SPLUNK_LICENSE_URI
       - DEBUG=true
       - SPLUNK_PASSWORD
+      - SPLUNK_UPGRADE=true
     ports:
       - 8000
       - 8089
@@ -185,6 +190,7 @@ services:
       - SPLUNK_LICENSE_URI
       - DEBUG=true
       - SPLUNK_PASSWORD
+      - SPLUNK_UPGRADE=true
     ports:
       - 8000
       - 8089


### PR DESCRIPTION
Changes
1. Splunk version upgraded to 7.2.1 and responding hash value is updated
2. Documentation format for tables in advanced usage page is updated to fix the collapsing table
3. Added example scenarios for Splunk upgrade
4. Added documentation for Splunk upgrade