### PR TITLE
Add python-requests install

### DIFF
--- a/base/debian-9/install.sh
+++ b/base/debian-9/install.sh
@@ -31,6 +31,7 @@ apt-get update
 # put back tools for customer support
 apt-cache show ansible
 apt-get install -y --no-install-recommends ansible curl sudo libgssapi-krb5-2 busybox procps
+apt-get install -y --no-install-recommends python-requests
 
 cd /bin
 ln -s busybox diff


### PR DESCRIPTION
Support new usage of requests.get() and requests.raise_for_status() functions
* Must be installed after ansible