### PR TITLE
Optionally keeping splunk sudo

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -1,6 +1,7 @@
 ## Advanced Usage ##
 This section shows several of the advanced functions of the container, as well as how to build a container
 from the github repo.
+
 ** Note: ** Not all sections below will leave your container in a supported state. See `docs/SETUP.md` for the list of officially supported configurations.
 
 ##### Building From Source (Unsupported) #####

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -1,7 +1,7 @@
 ## Advanced Usage ##
 This section shows several of the advanced functions of the container, as well as how to build a container
-from the github repo.  
-** Note: ** Not all sections below will leave your container in a supported state. See `docs/SETUP.md` for the list of officially supported configurations. 
+from the github repo.
+** Note: ** Not all sections below will leave your container in a supported state. See `docs/SETUP.md` for the list of officially supported configurations.
 
 ##### Building From Source (Unsupported) #####
 1. Download the Splunk Docker GitHub repository to your local development environment:
@@ -9,7 +9,7 @@ from the github repo.
 git clone https://github.com/splunk/docker-splunk
 ```
 The supplied `Makefile` located inside the root of the project provides the ability to download any of the remaining
-components. 
+components.
 
 ** WARNING:** Modifications to the "base" image may result in Splunk being unable to start or run correctly.
 
@@ -20,7 +20,7 @@ make splunk
 
 ## Advanced Configurations ##
 Splunk's Docker container has several functions that can be configured. These options are specified by either supplying a `default.yml` file or
-by passing in environment variables. Below is a list of environment variables that may/must be used when starting the docker container. 
+by passing in environment variables. Below is a list of environment variables that may/must be used when starting the docker container.
 
 #### Valid Enterprise Environment Variables
 | Environment Variable Name | Description | Required for Standalone | Required for Search Head Clustering | Required for Index Clustering |
@@ -46,6 +46,7 @@ by passing in environment variables. Below is a list of environment variables th
 | SPLUNK_SHC_SECRET | Search Head Clustering Shared secret | no | yes | no |
 | SPLUNK_IDXC_SECRET | Indexer Clustering Shared Secret | no | no | yes |
 | NO_HEALTHCHECK | Disable the Splunk healthcheck script | no | no | yes |
+| SPLUNK_ENABLE_SUDO | Enables the ability for the splunk user to run sudo | no | no | no |
 
 * Password must be set either in default.yml or as the environment variable `SPLUNK_PASSWORD`
 
@@ -177,7 +178,7 @@ $ docker run --rm -e "SPLUNK_PASSWORD=<password>" splunk/splunk-debian-9:latest 
 ```
 
 ## Starting Splunk Enterprise with a default.yml file ##
-The following command is used to supply an advanced configuration to the container, specify a url location of the `default.yml` file, or volume mount in a default. To use the 
+The following command is used to supply an advanced configuration to the container, specify a url location of the `default.yml` file, or volume mount in a default. To use the
 `default.yml` created on the previous section, use the following syntax:
 
 ```
@@ -205,14 +206,14 @@ You can create a simple cluster with Docker Swarm using the following command:
 ```
 Please note that the provisioning process will run for a few minutes after this command completes
 while the Ansible plays run. Also, be warned that this configuration requires a lot of resources
-so running this on your laptop may make it hot and slow. 
+so running this on your laptop may make it hot and slow.
 
-To view port mappings run: 
+To view port mappings run:
 ```
- $> docker ps 
+ $> docker ps
 ```
 After several minutes, you should be able to log into one of the search heads `sh#`
-using the default username `admin` and the password you input at installation, or set through the Splunk UI. 
+using the default username `admin` and the password you input at installation, or set through the Splunk UI.
 
 Once finished, you can remove the cluster by running:
 ```
@@ -220,7 +221,7 @@ Once finished, you can remove the cluster by running:
 ```
 
 The `cluster_absolute_unit.yaml` file located in the test_scenarios folder is a
-Docker Compose file that can be used to mimic this type of deployment. 
+Docker Compose file that can be used to mimic this type of deployment.
 
 ```
 version: "3.6"
@@ -260,7 +261,7 @@ services:
       - 8000
     volumes:
       - ./defaults:/tmp/defaults
-``` 
+```
 It's important to understand how Docker knows how to configure each major container. Below is the above template broken down into its simplest components:
 
 ```
@@ -307,7 +308,7 @@ docker-compose -f cluster_absolute_unit.yaml up -d
 ```
 
 To support Splunk Enterprise's complex configurations, the Docker container utilizes Ansible which performs the required provisioning
-commands. You can use the `docker log` command to follow these logs. 
+commands. You can use the `docker log` command to follow these logs.
 
 `docker ps` will show a list of all the current running instances on this node. The cluster master gives the best indication of cluster health without needing to check every container.
 ```
@@ -359,7 +360,7 @@ Wednesday 29 August 2018  09:28:29 +0000 (0:00:00.123)       0:01:23.447 ******
 changed: [localhost] => (item=USERNAME)
 changed: [localhost] => (item=PASSWORD)
 ```
-Once Ansible has finished running, a summary screen will be displayed. 
+Once Ansible has finished running, a summary screen will be displayed.
 
 ```
 PLAY RECAP *********************************************************************
@@ -402,6 +403,6 @@ fatal: [localhost]: FAILED! => {"cache_control": "private", "changed": false, "c
 	to retry, use: --limit @/opt/ansible/ansible-retry/site.retry
 ```
 
-In the above example, the `default.yml` file didn't contain a password, nor was an environment variable set. 
+In the above example, the `default.yml` file didn't contain a password, nor was an environment variable set.
 
 Please see the [troubleshooting](TROUBLESHOOTING.md) section for more common issues that can occur. There you will also find instructions for producing Splunk diagnostics for support such as `splunk diag`, as well as instructions for downloading the full Splunk `ansible.log` file.

--- a/splunk/debian-9/Dockerfile
+++ b/splunk/debian-9/Dockerfile
@@ -29,6 +29,8 @@ ENV SPLUNK_HOME=/opt/splunk \
 # Setup users and download Splunk
 RUN groupadd -r ${SPLUNK_GROUP} \
     && useradd -r -m -g ${SPLUNK_GROUP} ${SPLUNK_USER} \
+    && usermod -aG sudo ${SPLUNK_USER} \
+    && sed -i -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers \
     && echo "Downloading Splunk and validating the checksum at: ${SPLUNK_BUILD_URL}" \
     && wget -qO /tmp/${SPLUNK_FILENAME} ${SPLUNK_BUILD_URL} \
     && wget -qO /tmp/${SPLUNK_FILENAME}.sha512 ${SPLUNK_BUILD_URL}.sha512 \

--- a/splunk/debian-9/entrypoint.sh
+++ b/splunk/debian-9/entrypoint.sh
@@ -31,7 +31,7 @@ teardown() {
 	${SPLUNK_HOME}/bin/splunk stop 2>/dev/null || true
 }
 
-trap teardown SIGINT SIGTERM 
+trap teardown SIGINT SIGTERM
 
 prep_ansible() {
 	cd ${SPLUNK_ANSIBLE_HOME}
@@ -73,13 +73,13 @@ start_and_exit() {
 }
 
 start() {
-    trap teardown EXIT 
+    trap teardown EXIT
 	start_and_exit
     watch_for_failure
 }
 
 restart(){
-    trap teardown EXIT 
+    trap teardown EXIT
 	sh -c "echo 'restarting' > ${SPLUNK_HOME}/splunk-container.state"
     prep_ansible
   	${SPLUNK_HOME}/bin/splunk stop 2>/dev/null || true
@@ -89,15 +89,15 @@ restart(){
 
 help() {
 	cat << EOF
-  ____        _             _      __  
- / ___| _ __ | |_   _ _ __ | | __  \ \\ 
+  ____        _             _      __
+ / ___| _ __ | |_   _ _ __ | | __  \ \\
  \___ \| '_ \| | | | | '_ \| |/ /   \ \\
   ___) | |_) | | |_| | | | |   <    / /
- |____/| .__/|_|\__,_|_| |_|_|\_\  /_/ 
-       |_|                            
+ |____/| .__/|_|\__,_|_| |_|_|\_\  /_/
+       |_|
 ========================================
 
-Environment Variables: 
+Environment Variables:
   * SPLUNK_USER - user under which to run Splunk (default: splunk)
   * SPLUNK_GROUP - group under which to run Splunk (default: splunk)
   * SPLUNK_HOME - home directory where Splunk gets installed (default: /opt/splunk)
@@ -110,15 +110,15 @@ Environment Variables:
         - splunk_deployer
         - splunk_license_master
         - splunk_cluster_master
-        - splunk_heavy_forwarder 
+        - splunk_heavy_forwarder
   * SPLUNK_LICENSE_URI - URI or local file path (absolute path in the container) to a Splunk license
-  * SPLUNK_STANDALONE_URL, SPLUNK_INDEXER_URL, ... - comma-separated list of resolvable aliases to properly bring-up a distributed environment. 
+  * SPLUNK_STANDALONE_URL, SPLUNK_INDEXER_URL, ... - comma-separated list of resolvable aliases to properly bring-up a distributed environment.
                                                      This is optional for standalones, but required for multi-node Splunk deployments.
   * SPLUNK_BUILD_URL - URL to a Splunk build which will be installed (instead of the image's default build)
   * SPLUNK_APPS_URL - comma-separated list of URLs to Splunk apps which will be downloaded and installed
 
 Examples:
-  * docker run -it -p 8000:8000 splunk/splunk start 
+  * docker run -it -p 8000:8000 splunk/splunk start
   * docker run -it -e SPLUNK_START_ARGS=--accept-license -p 8000:8000 -p 8089:8089 splunk/splunk start
   * docker run -it -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_LICENSE_URI=http://example.com/splunk.lic -p 8000:8000 splunk/splunk start
   * docker run -it -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_INDEXER_URL=idx1,idx2 -e SPLUNK_SEARCH_HEAD_URL=sh1,sh2 -e SPLUNK_ROLE=splunk_search_head --hostname sh1 --network splunknet --network-alias sh1 -e SPLUNK_PASSWORD=helloworld -e SPLUNK_LICENSE_URI=http://example.com/splunk.lic splunk/splunk start
@@ -126,6 +126,11 @@ Examples:
 EOF
     exit 1
 }
+
+if [[ "$SPLUNK_ENABLE_SUDO" != "true" ]]; then
+    sudo bash -c "sudo sed -i -e 's/%sudo ALL=NOPASSWD:ALL/%sudo ALL=(ALL:ALL) ALL/g' /etc/sudoers ; sudo deluser -q splunk sudo"
+fi
+
 case "$1" in
 	start|start-service)
 		shift

--- a/uf/debian-9/entrypoint.sh
+++ b/uf/debian-9/entrypoint.sh
@@ -72,13 +72,13 @@ start_and_exit() {
 }
 
 start() {
-    trap teardown EXIT 
+    trap teardown EXIT
 	start_and_exit
     watch_for_failure
 }
 
 restart(){
-	trap teardown EXIT 
+	trap teardown EXIT
 	sh -c "echo 'restarting' > ${SPLUNK_HOME}/splunk-container.state"
     prep_ansible
   	${SPLUNK_HOME}/bin/splunk stop 2>/dev/null || true
@@ -101,7 +101,7 @@ Environment Variables:
   * SPLUNK_GROUP - group under which to run Splunk (default: splunk)
   * SPLUNK_HOME - home directory where Splunk gets installed (default: /opt/splunk)
   * SPLUNK_START_ARGS - arguments to pass into the Splunk start command; you must include '--accept-license' to start Splunk (default: none)
-  * SPLUNK_STANDALONE_URL, SPLUNK_INDEXER_URL, ... - comma-separated list of resolvable aliases to properly bring-up a distributed environment. 
+  * SPLUNK_STANDALONE_URL, SPLUNK_INDEXER_URL, ... - comma-separated list of resolvable aliases to properly bring-up a distributed environment.
                                                      This is optional for the UF, but necessary if you want to forward logs to another containerized Splunk instance
   * SPLUNK_BUILD_URL - URL to a Splunk Universal Forwarder build which will be installed (instead of the image's default build)
   * SPLUNK_DEPLOYMENT_SERVER - A network alias to Splunk deployment server
@@ -113,6 +113,11 @@ Environment Variables:
 EOF
     exit 1
 }
+
+if [[ "$SPLUNK_ENABLE_SUDO" != "true" ]]; then
+    sudo bash -c "sudo sed -i -e 's/%sudo ALL=NOPASSWD:ALL/%sudo ALL=(ALL:ALL) ALL/g' /etc/sudoers ; sudo deluser -q splunk sudo"
+fi
+
 case "$1" in
 	start|start-service)
 		shift


### PR DESCRIPTION
This adds splunk back to the sudo group and then remove it in the
entrypoint.sh by default, but allows for a flag to keep splunk in the
sudo group at runtime.

Addresses #74 

> Note: I have a vim plug-in that removes extraneous whitespace from the end of lines. (I highly recommend it using something like it.) Hence the extra line changes. If need be, I can disable it and reduce the number of changed lines.