### PR TITLE
Getting tests to pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,13 +107,7 @@ test: clean ansible test_helper test_collection_cleanup
 
 test_helper:
 	@echo 'Starting container to run tests...'
-	docker run -d --rm --name=${TEST_IMAGE_NAME} --net=host -v /var/run/docker.sock:/var/run/docker.sock --entrypoint /bin/sh python:2.7.15-alpine3.7 -c 'tail -f /dev/null'
-
-	@echo 'Create directories'
-	docker exec -i ${TEST_IMAGE_NAME} /bin/sh -c "mkdir -p $(shell pwd)"
-
-	@echo 'Copy source code into container'
-	docker cp . ${TEST_IMAGE_NAME}:$(shell pwd)
+	docker run -d --rm --name=${TEST_IMAGE_NAME} --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $(shell pwd):$(shell pwd) --entrypoint /bin/sh python:2.7.15-alpine3.7 -c 'tail -f /dev/null'
 
 	@echo 'Install test requirements'
 	docker exec -i ${TEST_IMAGE_NAME} /bin/sh -c "pip install -r $(shell pwd)/tests/requirements.txt --upgrade"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ IMAGE_VERSION ?= "latest"
 DOCKER_BUILD_FLAGS =
 TEST_IMAGE_NAME = "spldocker"
 SPLUNK_ANSIBLE_REPO ?= https://github.com/splunk/splunk-ansible.git
-SPLUNK_ANSIBLE_BRANCH ?= master
+SPLUNK_ANSIBLE_BRANCH ?= develop
 SPLUNK_COMPOSE ?= cluster_absolute_unit.yaml
 # Set Splunk version/build parameters here to define downstream URLs and file names
 SPLUNK_PRODUCT := splunk

--- a/test_scenarios/1so_custombuild.yaml
+++ b/test_scenarios/1so_custombuild.yaml
@@ -11,7 +11,7 @@ services:
       splunknet:
         aliases:
           - so1
-    image: splunk/splunk:latest
+    image: ${SPLUNK_IMAGE:-splunk/splunk:latest}
     hostname: so1
     container_name: so1
     environment:

--- a/test_scenarios/1so_trial.yaml
+++ b/test_scenarios/1so_trial.yaml
@@ -7,7 +7,7 @@ networks:
 
 services:
   so1:
-    image: splunk/splunk:latest
+    image: ${SPLUNK_IMAGE:-splunk/splunk:latest}
     hostname: so1
     container_name: so1
     environment:

--- a/test_scenarios/1uf1so.yaml
+++ b/test_scenarios/1uf1so.yaml
@@ -7,7 +7,7 @@ networks:
 
 services:
   uf1:
-    image: splunk/universalforwarder:latest
+    image: ${UF_IMAGE:-splunk/universalforwarder:latest}
     hostname: uf1
     container_name: uf1
     environment:
@@ -20,7 +20,7 @@ services:
       - 8089
 
   so1:
-    image: splunk/splunk:latest
+    image: ${SPLUNK_IMAGE:-splunk/splunk:latest}
     hostname: so1
     container_name: so1
     environment:

--- a/tests/test_centos_7.py
+++ b/tests/test_centos_7.py
@@ -288,6 +288,9 @@ class TestCentos7(object):
         self.client.remove_container(cid.get("Id"), v=True, force=True)
         password = re.search("  password: (.*)", output).group(1).strip()
         assert password
+        # Set the splunk.secret key
+        output = re.sub(r'  secret: null', r'  secret: hello-world', output)
+        # Write the default.yml to a file
         with open(os.path.join(FIXTURES_DIR, "default.yml"), "w") as f:
             f.write(output)
         # Create the container and mount the default.yml
@@ -316,6 +319,10 @@ class TestCentos7(object):
             splunkd_port = self.client.port(cid.get("Id"), 8089)
             resp = requests.get("https://localhost:{}/services/server/info".format(splunkd_port[0]["HostPort"]), auth=("admin", password), verify=False)
             assert resp.status_code == 200
+            # Check the splunk.secret file
+            exec_obj = self.client.exec_create(cid, "cat /opt/splunk/etc/auth/splunk.secret", user="splunk")
+            stdout = self.client.exec_start(exec_obj)
+            assert "hello-world" in stdout
         except Exception as e:
             print e
             self.logger.error(e)

--- a/tests/test_centos_7.py
+++ b/tests/test_centos_7.py
@@ -38,9 +38,9 @@ file_handler.setFormatter(formatter)
 LOGGER.addHandler(file_handler)
 
 # Docker varaibles
-BASE_IMAGE_NAME = "base-debian-9"
-SPLUNK_IMAGE_NAME = "splunk-debian-9"
-UF_IMAGE_NAME = "splunkforwarder-debian-9"
+BASE_IMAGE_NAME = "base-centos-7"
+SPLUNK_IMAGE_NAME = "splunk-centos-7"
+UF_IMAGE_NAME = "splunkforwarder-centos-7"
 # Splunk variables
 SPLUNK_VERSION = "7.2.0"
 SPLUNK_BUILD = "8c86330ac18"
@@ -54,7 +54,7 @@ def generate_random_string():
 
 
 @pytest.mark.large
-class TestDebian9(object):
+class TestCentos7(object):
     """
     Test suite to validate the Splunk Docker image
     """
@@ -65,19 +65,19 @@ class TestDebian9(object):
     def setup_class(cls):
         cls.client = docker.APIClient()
         # Build base
-        response = cls.client.build(path=os.path.join(REPO_DIR, "base", "debian-9"), 
+        response = cls.client.build(path=os.path.join(REPO_DIR, "base", "centos-7"), 
                                     buildargs={"SPLUNK_BUILD_URL": SPLUNK_BUILD_URL, "SPLUNK_FILENAME": SPLUNK_FILENAME},
                                     tag=BASE_IMAGE_NAME)
         for line in response:
             print line,
         # Build splunk
-        response = cls.client.build(path=REPO_DIR, dockerfile=os.path.join("splunk", "debian-9", "Dockerfile"), 
+        response = cls.client.build(path=REPO_DIR, dockerfile=os.path.join("splunk", "centos-7", "Dockerfile"), 
                                     buildargs={"SPLUNK_BUILD_URL": SPLUNK_BUILD_URL, "SPLUNK_FILENAME": SPLUNK_FILENAME},
                                     tag=SPLUNK_IMAGE_NAME)
         for line in response:
             print line,
         # Build splunkforwarder
-        response = cls.client.build(path=REPO_DIR, dockerfile=os.path.join("uf", "debian-9", "Dockerfile"), 
+        response = cls.client.build(path=REPO_DIR, dockerfile=os.path.join("uf", "centos-7", "Dockerfile"), 
                                     buildargs={"SPLUNK_BUILD_URL": UF_BUILD_URL, "SPLUNK_FILENAME": UF_FILENAME},
                                     tag=UF_IMAGE_NAME)
         for line in response:
@@ -197,8 +197,6 @@ class TestDebian9(object):
                         continue
                     self.logger.error(e)
                     return False
-                finally:
-                    time.sleep(5)
         return True
     
     def get_container_logs(self, container_id):
@@ -319,6 +317,7 @@ class TestDebian9(object):
             resp = requests.get("https://localhost:{}/services/server/info".format(splunkd_port[0]["HostPort"]), auth=("admin", password), verify=False)
             assert resp.status_code == 200
         except Exception as e:
+            print e
             self.logger.error(e)
             assert False
         finally:

--- a/tests/test_centos_7.py
+++ b/tests/test_centos_7.py
@@ -279,7 +279,6 @@ class TestCentos7(object):
         self.client.remove_container(cid.get("Id"), v=True, force=True)
         assert "License not accepted, please ensure the environment variable SPLUNK_START_ARGS contains the '--accept-license' flag" in output
     
-    @pytest.mark.skipif(os.path.isfile("/.dockerenv"), reason="Volume mounting is wonky from within another container")
     def test_adhoc_1so_using_default_yml(self):
         # Generate default.yml
         cid = self.client.create_container(SPLUNK_IMAGE_NAME, tty=True, command="create-defaults")

--- a/tests/test_debian_9.py
+++ b/tests/test_debian_9.py
@@ -290,6 +290,9 @@ class TestDebian9(object):
         self.client.remove_container(cid.get("Id"), v=True, force=True)
         password = re.search("  password: (.*)", output).group(1).strip()
         assert password
+        # Set the splunk.secret key
+        output = re.sub(r'  secret: null', r'  secret: hello-world', output)
+        # Write the default.yml to a file
         with open(os.path.join(FIXTURES_DIR, "default.yml"), "w") as f:
             f.write(output)
         # Create the container and mount the default.yml
@@ -318,6 +321,10 @@ class TestDebian9(object):
             splunkd_port = self.client.port(cid.get("Id"), 8089)
             resp = requests.get("https://localhost:{}/services/server/info".format(splunkd_port[0]["HostPort"]), auth=("admin", password), verify=False)
             assert resp.status_code == 200
+            # Check the splunk.secret file
+            exec_obj = self.client.exec_create(cid, "cat /opt/splunk/etc/auth/splunk.secret", user="splunk")
+            stdout = self.client.exec_start(exec_obj)
+            assert "hello-world" in stdout
         except Exception as e:
             self.logger.error(e)
             assert False

--- a/tests/test_debian_9.py
+++ b/tests/test_debian_9.py
@@ -281,7 +281,6 @@ class TestDebian9(object):
         self.client.remove_container(cid.get("Id"), v=True, force=True)
         assert "License not accepted, please ensure the environment variable SPLUNK_START_ARGS contains the '--accept-license' flag" in output
     
-    @pytest.mark.skipif(os.path.isfile("/.dockerenv"), reason="Volume mounting is wonky from within another container")
     def test_adhoc_1so_using_default_yml(self):
         # Generate default.yml
         cid = self.client.create_container(SPLUNK_IMAGE_NAME, tty=True, command="create-defaults")


### PR DESCRIPTION
The UF tests are a little broken still, but so far the enterprise tests for standalone with debian + centos seem to be ok:
```
tests/test_debian_9.py::TestDebian9::test_splunk_entrypoint_create_defaults PASSED
tests/test_debian_9.py::TestDebian9::test_splunk_entrypoint_start_no_password PASSED
tests/test_debian_9.py::TestDebian9::test_splunk_entrypoint_start_no_accept_license PASSED
tests/test_debian_9.py::TestDebian9::test_uf_entrypoint_help PASSED
tests/test_debian_9.py::TestDebian9::test_uf_entrypoint_create_defaults PASSED
tests/test_debian_9.py::TestDebian9::test_uf_entrypoint_start_no_password PASSED
tests/test_debian_9.py::TestDebian9::test_uf_entrypoint_start_no_accept_license FAILED
tests/test_debian_9.py::TestDebian9::test_adhoc_1so_using_default_yml PASSED
tests/test_debian_9.py::TestDebian9::test_compose_1so_trial PASSED
tests/test_debian_9.py::TestDebian9::test_compose_1so_custombuild PASSED
tests/test_debian_9.py::TestDebian9::test_compose_1so_namedvolumes PASSED
tests/test_debian_9.py::TestDebian9::test_compose_1so_command_start PASSED
tests/test_debian_9.py::TestDebian9::test_compose_1so_command_start_service PASSED
tests/test_debian_9.py::TestDebian9::test_compose_1so_hec PASSED
tests/test_debian_9.py::TestDebian9::test_compose_1so_apps PASSED
tests/test_debian_9.py::TestDebian9::test_compose_1uf_hec FAILED
tests/test_debian_9.py::TestDebian9::test_compose_1uf_apps FAILED
tests/test_debian_9.py::TestDebian9::test_compose_1uf1so FAILED
```
```
tests/test_centos_7.py::TestCentos7::test_splunk_entrypoint_create_defaults PASSED
tests/test_centos_7.py::TestCentos7::test_splunk_entrypoint_start_no_password PASSED
tests/test_centos_7.py::TestCentos7::test_splunk_entrypoint_start_no_accept_license PASSED
tests/test_centos_7.py::TestCentos7::test_uf_entrypoint_help FAILED
tests/test_centos_7.py::TestCentos7::test_uf_entrypoint_create_defaults FAILED
tests/test_centos_7.py::TestCentos7::test_uf_entrypoint_start_no_password FAILED
tests/test_centos_7.py::TestCentos7::test_uf_entrypoint_start_no_accept_license FAILED
tests/test_centos_7.py::TestCentos7::test_adhoc_1so_using_default_yml PASSED
tests/test_centos_7.py::TestCentos7::test_compose_1so_trial PASSED
tests/test_centos_7.py::TestCentos7::test_compose_1so_custombuild PASSED
tests/test_centos_7.py::TestCentos7::test_compose_1so_namedvolumes PASSED
tests/test_centos_7.py::TestCentos7::test_compose_1so_command_start PASSED
tests/test_centos_7.py::TestCentos7::test_compose_1so_command_start_service PASSED
tests/test_centos_7.py::TestCentos7::test_compose_1so_hec PASSED
tests/test_centos_7.py::TestCentos7::test_compose_1so_apps PASSED
tests/test_centos_7.py::TestCentos7::test_compose_1uf_hec FAILED
tests/test_centos_7.py::TestCentos7::test_compose_1uf_apps FAILED
tests/test_centos_7.py::TestCentos7::test_compose_1uf1so FAILED
```