### PR TITLE
Expand entrypoint permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ base-windows-2016:
 	docker build ${DOCKER_BUILD_FLAGS} -t base-windows-2016:${IMAGE_VERSION} ./base/windows-2016
 
 ##### Splunk images #####
-enterprise: ansible splunk-debian-9 splunk-centos-7
+splunk: ansible splunk-debian-9 splunk-centos-7
 
 splunk-debian-9: base-debian-9 ansible
 	docker build ${DOCKER_BUILD_FLAGS} \

--- a/uf/debian-9/Dockerfile
+++ b/uf/debian-9/Dockerfile
@@ -49,9 +49,10 @@ RUN groupadd -r ${SPLUNK_GROUP} \
     && chown -R ${ANSIBLE_USER}:${ANSIBLE_GROUP} $CONTAINER_ARTIFACT_DIR 
 
 COPY splunk-ansible ${SPLUNK_ANSIBLE_HOME}
-RUN  chmod -R 555 ${SPLUNK_ANSIBLE_HOME}
-USER ${ANSIBLE_USER}
+RUN chmod -R 555 ${SPLUNK_ANSIBLE_HOME}
 COPY [ "uf/common-files/entrypoint.sh", "uf/common-files/checkstate.sh", "uf/common-files/createdefaults.py", "/sbin/"]
+RUN chmod 755 "/sbin/entrypoint.sh"
+USER ${ANSIBLE_USER}
 COPY [ "uf/common-files/bin/ta-dockerlogs_fileinput.tar.gz", "uf/common-files/bin/ta-dockerstats.tar.gz", "/tmp/" ]
 
 EXPOSE 8089 8088 9997


### PR DESCRIPTION
While testing the uf image, I was unable to access the entrypoint when the container is first started. It didn't have the correct permissions like the enterprise image (0755).