### PR TITLE
Adding test for HEC ssl disabled

### DIFF
--- a/tests/test_debian_9.py
+++ b/tests/test_debian_9.py
@@ -329,6 +329,66 @@ class TestDebian9(object):
             except OSError:
                 pass
 
+    def test_adhoc_1so_using_default_yml_hec_ssl_disabled(self):
+        # Generate default.yml
+        cid = self.client.create_container(SPLUNK_IMAGE_NAME, tty=True, command="create-defaults")
+        self.client.start(cid.get("Id"))
+        output = self.get_container_logs(cid.get("Id"))
+        self.client.remove_container(cid.get("Id"), v=True, force=True)
+        # Get the password
+        password = re.search("  password: (.*)", output).group(1).strip()
+        assert password
+        # Get the HEC token
+        hec_token = re.search("  hec_token: (.*)", output).group(1).strip()
+        assert hec_token
+        # Make sure hec_enableSSL is disabled
+        output = re.sub(r'  hec_enableSSL: 1', r'  hec_enableSSL: 0', output)
+        # Write the default.yml to a file
+        with open(os.path.join(FIXTURES_DIR, "default.yml"), "w") as f:
+            f.write(output)
+        # Create the container and mount the default.yml
+        cid = None
+        try:
+            splunk_container_name = generate_random_string()
+            cid = self.client.create_container(SPLUNK_IMAGE_NAME, tty=True, command="start", ports=[8089, 8088], 
+                                            volumes=["/tmp/defaults/"], name=splunk_container_name,
+                                            environment={"SPLUNK_START_ARGS": "--accept-license"},
+                                            host_config=self.client.create_host_config(binds=[FIXTURES_DIR + ":/tmp/defaults/"],
+                                                                                       port_bindings={8089: ("0.0.0.0",), 8088: ("0.0.0.0",)})
+                                            )
+            self.client.start(cid.get("Id"))
+            # Poll for the container to be healthy
+            for _ in range(10):
+                try:
+                    containers = self.client.containers(filters={"name": splunk_container_name})
+                    if "healthy" in containers[0]["Status"]:
+                        break
+                except Exception as e:
+                    self.logger.error(e)
+                finally:
+                    time.sleep(5)
+            # Check splunkd
+            time.sleep(10)
+            splunkd_port = self.client.port(cid.get("Id"), 8089)
+            resp = requests.get("https://localhost:{}/services/server/info".format(splunkd_port[0]["HostPort"]), auth=("admin", password), verify=False)
+            assert resp.status_code == 200
+            # Check HEC
+            hec_port = self.client.port(cid.get("Id"), 8088)
+            resp = requests.post("http://localhost:{}/services/collector/event".format(hec_port[0]["HostPort"]), 
+                                 headers={"Authorization": "Splunk {}".format(hec_token)},
+                                 json={"event": "hello world"})
+            assert resp.status_code == 200
+        except Exception as e:
+            self.logger.error(e)
+            assert False
+        finally:
+            if cid:
+                self.client.remove_container(cid.get("Id"), v=True, force=True)
+            try:
+                os.remove(os.path.join(FIXTURES_DIR, "default.yml"))
+            except OSError:
+                pass
+
     def test_compose_1so_trial(self):
         # Standup deployment
         self.compose_file_name = "1so_trial.yaml"


### PR DESCRIPTION
Making sure this issue is covered in testing: https://github.com/splunk/docker-splunk/issues/66

Output:
```
$ pytest tests/test_debian_9.py::TestDebian9::test_adhoc_1so_using_default_yml_hec_ssl_disabled
===== test session starts =====
platform darwin -- Python 2.7.15, pytest-4.0.2, py-1.7.0, pluggy-0.8.0
rootdir: /Users/nwang/github/docker-splunk, inifile:
collected 1 item

tests/test_debian_9.py .                                                                                                   [100%]

===== warnings summary =====
tests/test_debian_9.py::TestDebian9::test_adhoc_1so_using_default_yml_hec_ssl_disabled
  /Users/nwang/github/docker-splunk/venv/lib/python2.7/site-packages/urllib3/connectionpool.py:847: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===== 1 passed, 1 warnings in 56.23 seconds =====
```