### PR TITLE
Add test 2idx2sh1cm.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           destintation: clair-scanner-logs
       - run:
           name: Running CI Tests
-          command: make test_ci
+          command: make run_tests_debian9
       - store_artifacts:
           path: test-results
           destination: test-results

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ uf-windows-2016: base-windows-2016 ansible
 
 ##### Tests #####
 sample-compose-up: sample-compose-down
-	docker-compose -f test_scenarios/${SPLUNK_COMPOSE} up -d
+	docker-compose -f test_scenarios/${SPLUNK_COMPOSE} up -d 
 
 sample-compose-down:
 	docker-compose -f test_scenarios/${SPLUNK_COMPOSE} down --volumes --remove-orphans || true
@@ -124,8 +124,6 @@ test: clean ansible test_setup all run_tests_centos7 run_tests_debian9
 test_centos7: clean ansible splunk-centos-7 uf-centos-7 test_setup run_tests_centos7
 
 test_debian9: clean ansible splunk-debian-9 uf-debian-9 test_setup run_tests_debian9
-
-test_ci: run_tests_centos7 run_tests_debian9
 
 run_tests_centos7:
 	@echo 'Running the super awesome tests; CentOS 7'

--- a/test_scenarios/2idx2sh1cm.yaml
+++ b/test_scenarios/2idx2sh1cm.yaml
@@ -1,0 +1,117 @@
+version: "3.6"
+
+networks:
+  splunknet:
+    driver: bridge
+    attachable: true
+
+services:
+  sh1:
+    networks:
+      splunknet:
+        aliases:
+          - sh1
+    image: ${SPLUNK_IMAGE:-splunk/splunk:latest}
+    command: start
+    hostname: sh1
+    container_name: sh1
+    environment:
+      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_INDEXER_URL=idx1,idx2
+      - SPLUNK_SEARCH_HEAD_URL=sh1,sh2
+      - SPLUNK_CLUSTER_MASTER_URL=cm1
+      - SPLUNK_ROLE=splunk_search_head
+      - SPLUNK_LICENSE_URI
+      - DEBUG=true
+      - SPLUNK_PASSWORD
+    ports:
+      - 8000
+      - 8089
+      
+  sh2:
+    networks:
+      splunknet:
+        aliases:
+          - sh2
+    image: ${SPLUNK_IMAGE:-splunk/splunk:latest}
+    command: start
+    hostname: sh2
+    container_name: sh2
+    environment:
+      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_INDEXER_URL=idx1,idx2
+      - SPLUNK_SEARCH_HEAD_URL=sh1,sh2
+      - SPLUNK_CLUSTER_MASTER_URL=cm1
+      - SPLUNK_ROLE=splunk_search_head
+      - SPLUNK_LICENSE_URI
+      - DEBUG=true
+      - SPLUNK_PASSWORD
+    ports:
+      - 8000
+      - 8089
+
+  cm1:
+    networks:
+      splunknet:
+        aliases:
+          - cm1
+    image: ${SPLUNK_IMAGE:-splunk/splunk:latest}
+    command: start
+    hostname: cm1
+    container_name: cm1
+    environment:
+      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_INDEXER_URL=idx1,idx2
+      - SPLUNK_SEARCH_HEAD_URL=sh1,sh2
+      - SPLUNK_CLUSTER_MASTER_URL=cm1
+      - SPLUNK_ROLE=splunk_cluster_master
+      - SPLUNK_LICENSE_URI
+      - DEBUG=true
+      - SPLUNK_PASSWORD
+    ports:
+      - 8000
+      - 8089
+
+  idx1:
+    networks:
+      splunknet:
+        aliases:
+          - idx1
+    image: ${SPLUNK_IMAGE:-splunk/splunk:latest}
+    command: start
+    hostname: idx1
+    container_name: idx1
+    environment:
+      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_INDEXER_URL=idx1,idx2
+      - SPLUNK_SEARCH_HEAD_URL=sh1,sh2
+      - SPLUNK_CLUSTER_MASTER_URL=cm1
+      - SPLUNK_ROLE=splunk_indexer
+      - SPLUNK_LICENSE_URI
+      - DEBUG=true
+      - SPLUNK_PASSWORD
+    ports:
+      - 8000
+      - 8089
+
+  idx2:
+    networks:
+      splunknet:
+        aliases:
+          - idx2
+    image: ${SPLUNK_IMAGE:-splunk/splunk:latest}
+    command: start
+    hostname: idx2
+    container_name: idx2
+    environment:
+      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_INDEXER_URL=idx1,idx2
+      - SPLUNK_SEARCH_HEAD_URL=sh1,sh2
+      - SPLUNK_CLUSTER_MASTER_URL=cm1
+      - SPLUNK_ROLE=splunk_indexer
+      - SPLUNK_LICENSE_URI
+      - DEBUG=true
+      - SPLUNK_PASSWORD
+    ports:
+      - 8000
+      - 8089

--- a/test_scenarios/2idx2sh1cm_idx3.yaml
+++ b/test_scenarios/2idx2sh1cm_idx3.yaml
@@ -1,0 +1,29 @@
+version: "3.6"
+
+networks:
+  splunknet:
+    driver: bridge
+    attachable: true
+
+services:
+  idx3:
+    networks:
+      splunknet:
+        aliases:
+          - idx3
+    image: ${SPLUNK_IMAGE:-splunk/splunk:latest}
+    command: start
+    hostname: idx3
+    container_name: idx3
+    environment:
+      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_INDEXER_URL=idx1,idx2,idx3
+      - SPLUNK_SEARCH_HEAD_URL=sh1,sh2
+      - SPLUNK_CLUSTER_MASTER_URL=cm1
+      - SPLUNK_ROLE=splunk_indexer
+      - SPLUNK_LICENSE_URI
+      - SPLUNK_PASSWORD
+      - DEBUG=true
+    ports:
+      - 8000
+      - 8089

--- a/tests/test_centos_7.py
+++ b/tests/test_centos_7.py
@@ -164,7 +164,7 @@ class TestCentos7(object):
         '''
         NOTE: This helper method can only be used for `compose up` scenarios where self.project_name is defined
         '''
-        retries = 5
+        retries = 10
         containers = self.client.containers(filters={"label": "com.docker.compose.project={}".format(self.project_name)})
         for container in containers:
             splunkd_port = self.client.port(container["Id"], 8089)[0]["HostPort"]
@@ -192,8 +192,23 @@ class TestCentos7(object):
             output += char
         return output
 
+    def handle_request_retry(self, method, url, kwargs):
+        RETRIES = 15
+        IMPLICIT_WAIT = 5
+        for n in range(RETRIES):
+            try:
+                resp = requests.request(method, url, **kwargs)
+                resp.raise_for_status()
+                return (resp.status_code, resp.content)
+            except Exception as e:
+                self.logger.error(e)
+                time.sleep(IMPLICIT_WAIT)
+                if n < RETRIES-1:
+                    continue
+        return (resp.status_code, resp.content)
+
     def extract_json(self, container_name):
-        retries = 5
+        retries = 15
         for i in range(retries):
             exec_command = self.client.exec_create(container_name, "cat opt/container_artifact/ansible_inventory.json")
             json_data = self.client.exec_start(exec_command)
@@ -234,8 +249,11 @@ class TestCentos7(object):
                     assert log_output["all"]["vars"]["splunk"]["role"] == "splunk_indexer"
                 elif role == "sh":
                     assert log_output["all"]["vars"]["splunk"]["role"] == "splunk_search_head"
+                elif role == "cm":
+                    assert log_output["all"]["vars"]["splunk"]["role"] == "splunk_cluster_master"
         except KeyError as e:
-            self.logger.error("{} key not found".format(e))            
+            self.logger.error("{} key not found".format(e))
+            assert False           
 
     def check_ansible(self, output):
         assert "ansible-playbook {}".format(ANSIBLE_VERSION) in output
@@ -683,38 +701,107 @@ class TestCentos7(object):
         self.project_name = generate_random_string()
         container_count, rc = self.compose_up()
 
-        output_sh1 = self.get_container_logs("sh1")
-        output_sh2 = self.get_container_logs("sh2")
-        output_idx1 = self.get_container_logs("idx1")
-        output_idx2 = self.get_container_logs("idx2")
-        log_json_sh1 = self.extract_json("sh1")
-        log_json_sh2 = self.extract_json("sh2")
-        log_json_idx1 = self.extract_json("idx1")
-        log_json_idx2 = self.extract_json("idx2")
+        container_names = ["idx1", "idx2", "sh1", "sh2"]
+        # Check ansible version & configs
+        logs_output = [self.get_container_logs(x) for x in container_names]
+        for log in logs_output:
+            self.check_ansible(log)
         assert rc == 0
         # Wait for containers to be healthy
         assert self.wait_for_containers(container_count)
         # Check Splunkd on all the containers
         assert self.check_splunkd("admin", self.password)
-        # Check ansible version & configs
-        self.check_ansible(output_sh1)
-        self.check_ansible(output_sh2)
-        self.check_ansible(output_idx1)
-        self.check_ansible(output_idx2)
         # Check values in log output
-        self.check_common_keys(log_json_sh1, "sh")
-        self.check_common_keys(log_json_sh2, "sh")
-        self.check_common_keys(log_json_idx1, "idx")
-        self.check_common_keys(log_json_idx2, "idx")
+        log_json = {}
+        for c in container_names:
+            log_json[c] = self.extract_json(c)
+        self.check_common_keys(log_json["sh1"], "sh")
+        self.check_common_keys(log_json["sh2"], "sh")
+        self.check_common_keys(log_json["idx1"], "idx")
+        self.check_common_keys(log_json["idx2"], "idx")
         try:
-            assert log_json_sh1["splunk_indexer"]["hosts"] == ["idx1", "idx2"]
-            assert log_json_sh1["splunk_search_head"]["hosts"] == ["sh1", "sh2"]
-            assert log_json_sh2["splunk_indexer"]["hosts"] == ["idx1", "idx2"]
-            assert log_json_sh2["splunk_search_head"]["hosts"] == ["sh1", "sh2"]
-            assert log_json_idx1["splunk_indexer"]["hosts"] == ["idx1", "idx2"]
-            assert log_json_idx1["splunk_search_head"]["hosts"] == ["sh1", "sh2"]
-            assert log_json_idx2["splunk_indexer"]["hosts"] == ["idx1", "idx2"]
-            assert log_json_idx2["splunk_search_head"]["hosts"] == ["sh1", "sh2"]
+            for c in container_names:
+                assert log_json[c]["splunk_indexer"]["hosts"] == ["idx1", "idx2"]
+                assert log_json[c]["splunk_search_head"]["hosts"] == ["sh1", "sh2"]
         except KeyError as e:
             self.logger.error(e)
             assert False
+
+
+    def test_compose_2idx2sh1cm(self):
+        # Standup deployment
+        self.compose_file_name = "2idx2sh1cm.yaml"
+        self.project_name = generate_random_string()
+        container_count, rc = self.compose_up()
+
+        container_names = ["idx1", "idx2", "sh1", "sh2", "cm1"]
+        # Check ansible version & configs
+        logs_output = [self.get_container_logs(x) for x in container_names]
+        for log in logs_output:
+            self.check_ansible(log)
+
+        assert rc == 0
+        # Wait for containers to be healthy
+        assert self.wait_for_containers(container_count)
+        # Check Splunkd on all the containers
+        assert self.check_splunkd("admin", self.password)
+        # Check values in log output
+        log_json = {}
+        for c in container_names:
+            log_json[c] = self.extract_json(c)
+        self.check_common_keys(log_json["sh1"], "sh")
+        self.check_common_keys(log_json["sh2"], "sh")
+        self.check_common_keys(log_json["idx1"], "idx")
+        self.check_common_keys(log_json["idx2"], "idx")
+        self.check_common_keys(log_json["cm1"], "cm")
+        try:
+            assert log_json["cm1"]["all"]["vars"]["splunk"]["indexer_cluster"] == True
+            for c in container_names:
+                assert log_json[c]["splunk_indexer"]["hosts"] == ["idx1", "idx2"]
+                assert log_json[c]["splunk_search_head"]["hosts"] == ["sh1", "sh2"]
+                assert log_json[c]["splunk_cluster_master"]["hosts"] == ["cm1"]
+        except KeyError as e:
+            self.logger.error(e)
+            assert False
+
+        # Check connections
+        idx_list = ["idx1", "idx2"]
+        sh_list = ["sh1", "sh2", "cm1"]
+
+        containers = self.client.containers(filters={"label": "com.docker.compose.service={}".format("cm1")})
+        splunkd_port = self.client.port(containers[0]["Id"], 8089)[0]["HostPort"]
+
+        status, content = self.handle_request_retry("GET", "https://localhost:{}/services/cluster/master/searchheads?output_mode=json".format(splunkd_port), 
+                                                    {"auth": ("admin", self.password), "verify": False})
+        assert status == 200
+        output = json.loads(content)
+        for sh in output["entry"]:
+            if sh["content"]["label"] in sh_list and sh["content"]["status"] == "Connected":
+                sh_list.remove(sh["content"]["label"])
+
+        status, content = self.handle_request_retry("GET", "https://localhost:{}/services/cluster/master/peers?output_mode=json".format(splunkd_port), 
+                                                    {"auth": ("admin", self.password), "verify": False})
+        assert status == 200
+        output = json.loads(content)
+        for idx in output["entry"]:
+            if idx["content"]["label"] in idx_list and idx["content"]["status"] == "Up":
+                idx_list.remove(idx["content"]["label"])
+
+        assert len(idx_list) == 0 and len(sh_list) == 0
+        # Add one more indexer
+        self.compose_file_name = "2idx2sh1cm_idx3.yaml"
+        container_count, rc = self.compose_up()
+        retries = 10
+        for n in range(retries):
+            status, content = self.handle_request_retry("GET", "https://localhost:{}/services/cluster/master/peers?output_mode=json".format(splunkd_port), 
+                                                {"auth": ("admin", self.password), "verify": False})
+            assert status == 200
+            output = json.loads(content)
+            for idx in output["entry"]:
+                if idx["content"]["label"] == "idx3" and idx["content"]["status"] == "Up":
+                    break
+            else:
+                time.sleep(10)
+                if n < retries-1:
+                    continue
+                assert False

--- a/tests/test_debian_9.py
+++ b/tests/test_debian_9.py
@@ -934,4 +934,3 @@ class TestDebian9(object):
                 if n < retries-1:
                     continue
                 assert False
-


### PR DESCRIPTION
Added a test for `2idx2sh1cm.yaml` that verifies the peers and search heads from the cluster master. 
Also updated `2idx2sh` test to check that each search head can see its peers