### PR TITLE
Extracting splunk-ansible sha for future traceability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ ansible:
 	else \
 		git clone ${SPLUNK_ANSIBLE_REPO} --branch ${SPLUNK_ANSIBLE_BRANCH}; \
 	fi
+	cd splunk-ansible && git rev-parse HEAD > version.txt
 
 ##### Base images #####
 base: base-debian-9 base-centos-7 base-windows-2016

--- a/tests/test_debian_9.py
+++ b/tests/test_debian_9.py
@@ -349,6 +349,27 @@ class TestDebian9(object):
         output = self.get_container_logs(cid.get("Id"))
         self.client.remove_container(cid.get("Id"), v=True, force=True)
         assert "License not accepted, please ensure the environment variable SPLUNK_START_ARGS contains the '--accept-license' flag" in output
+
+    def test_splunk_entrypoint_no_provision(self):
+        cid = None
+        try:
+            # Run container
+            cid = self.client.create_container(SPLUNK_IMAGE_NAME, tty=True, command="no-provision")
+            cid = cid.get("Id")
+            self.client.start(cid)
+            # Wait a bit
+            time.sleep(5)
+            # If the container is still running, we should be able to exec inside
+            # Check that the git SHA exists in /opt/ansible
+            exec_command = self.client.exec_create(cid, "cat /opt/ansible/version.txt")
+            std_out = self.client.exec_start(exec_command)
+            assert len(std_out.strip()) == 40
+        except Exception as e:
+            self.logger.error(e)
+            raise e
+        finally:
+            if cid:
+                self.client.remove_container(cid, v=True, force=True)
     
     def test_uf_entrypoint_help(self):
         # Run container
@@ -385,6 +406,27 @@ class TestDebian9(object):
         output = self.get_container_logs(cid.get("Id"))
         self.client.remove_container(cid.get("Id"), v=True, force=True)
         assert "License not accepted, please ensure the environment variable SPLUNK_START_ARGS contains the '--accept-license' flag" in output
+
+    def test_uf_entrypoint_no_provision(self):
+        cid = None
+        try:
+            # Run container
+            cid = self.client.create_container(UF_IMAGE_NAME, tty=True, command="no-provision")
+            cid = cid.get("Id")
+            self.client.start(cid)
+            # Wait a bit
+            time.sleep(5)
+            # If the container is still running, we should be able to exec inside
+            # Check that the git SHA exists in /opt/ansible
+            exec_command = self.client.exec_create(cid, "cat /opt/ansible/version.txt")
+            std_out = self.client.exec_start(exec_command)
+            assert len(std_out.strip()) == 40
+        except Exception as e:
+            self.logger.error(e)
+            raise e
+        finally:
+            if cid:
+                self.client.remove_container(cid, v=True, force=True)
     
     def test_adhoc_1so_using_default_yml(self):
         # Generate default.yml


### PR DESCRIPTION
I realized during the last release, we forgot to up the version.txt in splunk-ansible. However, static semvar versioning might not be ideal given how we're pulling in splunk-ansible. 

I added a section to extract the latest git sha from splunk-ansible and update the version.txt from that. Now all images should have a way to track if the splunk-ansible embedded is indeed the one you can expect.