### PR TITLE
Misc multistage-build post-merge tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ IMAGE_VERSION ?= "latest"
 NONQUOTE_IMAGE_VERSION := $(patsubst "%",%,$(IMAGE_VERSION))
 DOCKER_BUILD_FLAGS ?=
 SPLUNK_ANSIBLE_REPO ?= https://github.com/splunk/splunk-ansible.git
-SPLUNK_ANSIBLE_BRANCH ?= multistage-build
+SPLUNK_ANSIBLE_BRANCH ?= develop
 SPLUNK_COMPOSE ?= cluster_absolute_unit.yaml
 # Set Splunk version/build parameters here to define downstream URLs and file names
 SPLUNK_PRODUCT := splunk

--- a/splunk/common-files/Dockerfile
+++ b/splunk/common-files/Dockerfile
@@ -70,7 +70,7 @@ EXPOSE 8000/tcp 8089/tcp
 #
 FROM minimal as bare
 COPY --from=package --chown=splunk:splunk /extras /opt
-EXPOSE 4001 8000 8065 8088 8089 8191 9887 9997
+EXPOSE 8000 8065 8088 8089 8191 9887 9997
 VOLUME [ "/opt/splunk/etc", "/opt/splunk/var" ]
 
 


### PR DESCRIPTION
Updated Makefile to use develop branch of splunk-ansible instead of multistage-build

Updated Dockerfile to remove port 4001 as per Nelson's earlier PR
https://github.com/splunk/docker-splunk/pull/162