### PR TITLE
fix env variables in minimal image

### DIFF
--- a/splunk/common-files/Dockerfile
+++ b/splunk/common-files/Dockerfile
@@ -41,9 +41,9 @@ FROM ${SPLUNK_BASE_IMAGE}:latest as minimal
 LABEL maintainer="support@splunk.com"
 ENV SPLUNK_HOME=/opt/splunk \
     SPLUNK_GROUP=splunk \
-    SPLUNK_USER=splunk \
-    TMPSPLUNKDIR=${SPLUNK_HOME}/tmp \
-    TMPETCDIR=${TMPSPLUNKDIR}/etc
+    SPLUNK_USER=splunk
+ENV TMPSPLUNKDIR=${SPLUNK_HOME}/tmp
+ENV TMPETCDIR=${TMPSPLUNKDIR}/etc
 
 # Currently kubernetes only accepts UID and not USER field to
 # start a container as a particular user. So we create Splunk


### PR DESCRIPTION
the old Dockerfile ended up with  the following values:

```
splunk@194e7a01458d:/opt/splunk$ echo $TMPETCDIR
/etc
splunk@194e7a01458d:/opt/splunk$ echo $TMPSPLUNKDIR
/tmp
```

we want:
```
splunk@194e7a01458d:/opt/splunk$ echo $TMPETCDIR
/opt/splunk/tmp
splunk@194e7a01458d:/opt/splunk$ echo $TMPSPLUNKDIR
/opt/splunk/tmp/etc
```