### PR TITLE
Remove trailing slash for SPLUNK_HOME

### DIFF
--- a/test_scenarios/kubernetes/3idxc3shc1cm1lm1dep-pvc/splunk-indexer-statefulset-persistent.yaml
+++ b/test_scenarios/kubernetes/3idxc3shc1cm1lm1dep-pvc/splunk-indexer-statefulset-persistent.yaml
@@ -49,7 +49,7 @@ spec:
           image: splunk/splunk:latest
           env:
             - name: SPLUNK_HOME
-              value: /opt/splunk/
+              value: /opt/splunk
             - name: SPLUNK_DEFAULTS_URL
               value: http://splunk-defaults/default.yml
             - name: SPLUNK_START_ARGS


### PR DESCRIPTION
Removes a trailing slash when setting the SPLUNK_HOME variable, which may cause Indexers to fail with the message "ERROR: Couldn't read "/opt/splunk//etc/splunk-launch.conf" -- maybe $SPLUNK_HOME or $SPLUNK_ETC is set wrong?" due to duplicate slashes.