### PR TITLE
Make minimal excludes script more flexible

### DIFF
--- a/splunk/common-files/make-minimal-exclude.py
+++ b/splunk/common-files/make-minimal-exclude.py
@@ -41,3 +41,6 @@ if m and m.group(1):
             print "*/etc/apps/gettingstarted*"
         else:
             print "*/etc/apps/splunk_metrics_workspace*"
+    elif int(m.group(1)) > 7:
+        print EXCLUDE_V7
+        print "*/etc/apps/splunk_metrics_workspace*"


### PR DESCRIPTION
Updated script used to generate list of files to exclude from minimal images, so that it supports major version numbers greater than 7. Note that manual review of file diffs for every major.minor and corresponding updates for this script is still recommended.