### PR TITLE
Update py23 images

### DIFF
--- a/py23-image/centos-7/Dockerfile
+++ b/py23-image/centos-7/Dockerfile
@@ -20,6 +20,6 @@ RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
     && ln -sf /usr/bin/pip2 /usr/bin/pip \
     && ln -sf /usr/bin/pip3.7 /usr/bin/pip3
 RUN yum remove -y --setopt=tsflags=noscripts gcc openssl-devel bzip2-devel libffi-devel \
-    && yum -y autoremove \
+    && yum autoremove -y \
     && yum clean all
 RUN pip3 --no-cache-dir install ansible requests

--- a/py23-image/centos-7/Dockerfile
+++ b/py23-image/centos-7/Dockerfile
@@ -3,14 +3,23 @@ FROM ${SPLUNK_PRODUCT}-centos-7:latest
 USER root
 
 RUN yum -y update
-RUN yum -y install python36 python36-requests
-RUN python3 -m ensurepip
+RUN yum -y install gcc openssl-devel bzip2-devel libffi-devel python-pip
 # INFRA-15385: manual installation of python 3.7 as default distro version is 3.6
 RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
     && tar xzf Python-3.7.4.tgz \
     && cd Python-3.7.4 \
     && ./configure --enable-optimizations --prefix=/usr \
-    && make altinstall \
+    && make install \
     && cd .. \
     && rm Python-3.7.4.tgz \
     && rm -r Python-3.7.4 \
+    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3.7 get-pip.py \
+    && rm -f get-pip.py \
+    #pip version is not automatically "fixed", unlike debian-based
+    && ln -sf /usr/bin/pip2 /usr/bin/pip \
+    && ln -sf /usr/bin/pip3.7 /usr/bin/pip3
+RUN yum remove -y --setopt=tsflags=noscripts gcc openssl-devel bzip2-devel libffi-devel \
+    && yum -y autoremove \
+    && yum clean all
+RUN pip3 --no-cache-dir install ansible requests

--- a/py23-image/centos-7/Dockerfile
+++ b/py23-image/centos-7/Dockerfile
@@ -5,3 +5,12 @@ USER root
 RUN yum -y update
 RUN yum -y install python36 python36-requests
 RUN python3 -m ensurepip
+# INFRA-15385: manual installation of python 3.7 as default distro version is 3.6
+RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
+    && tar xzf Python-3.7.4.tgz \
+    && cd Python-3.7.4 \
+    && ./configure --enable-optimizations --prefix=/usr \
+    && make altinstall \
+    && cd .. \
+    && rm Python-3.7.4.tgz \
+    && rm -r Python-3.7.4 \

--- a/py23-image/debian-10/Dockerfile
+++ b/py23-image/debian-10/Dockerfile
@@ -2,6 +2,6 @@ ARG SPLUNK_PRODUCT=splunk
 FROM ${SPLUNK_PRODUCT}-debian-10:latest
 USER root
 
-RUN apt update
+RUN apt-get update
 RUN apt-get install -y --no-install-recommends python3 python3-pip python3-setuptools python3-requests python3-yaml
 RUN pip3 --no-cache-dir install ansible

--- a/py23-image/debian-9/Dockerfile
+++ b/py23-image/debian-9/Dockerfile
@@ -3,4 +3,28 @@ FROM ${SPLUNK_PRODUCT}-debian-9:latest
 USER root
 
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends python3 python3-pip python3-requests
+RUN apt-get install -y gcc make \
+    build-essential checkinstall libreadline-gplv2-dev libncursesw5-dev libssl-dev \
+    libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev
+# INFRA-15385: manual installation of python 3.7 as default distro version is 3.5
+RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
+    && tar xzf Python-3.7.4.tgz \
+    && cd Python-3.7.4 \
+    && ./configure --enable-optimizations --prefix=/usr \
+    && make altinstall \
+    && cd .. \
+    && rm Python-3.7.4.tgz \
+    && rm -r Python-3.7.4 \
+    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3.7 get-pip.py \
+    && rm -f get-pip.py
+#removing all intermediate dependencies. All the stuff below comes up to 200+MB
+RUN apt-get remove --purge -y gcc make build-essential checkinstall libreadline-gplv2-dev libncursesw5-dev \
+    libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev \
+    && apt autoremove -y \
+    && apt autoclean
+#doing this in case there is an older version of python3 installed
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 \
+    #lsb_release not available on python 3.6 and above, but is required by most debian-based image for pip(3)
+    && ln -s /usr/share/pyshared/lsb_release.py /usr/lib/python3.7/site-packages/lsb_release.py
+RUN pip3 --no-cache-dir install ansible requests

--- a/py23-image/debian-9/Dockerfile
+++ b/py23-image/debian-9/Dockerfile
@@ -11,7 +11,7 @@ RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
     && tar xzf Python-3.7.4.tgz \
     && cd Python-3.7.4 \
     && ./configure --enable-optimizations --prefix=/usr \
-    && make altinstall \
+    && make install \
     && cd .. \
     && rm Python-3.7.4.tgz \
     && rm -r Python-3.7.4 \
@@ -23,8 +23,4 @@ RUN apt-get remove --purge -y gcc make build-essential checkinstall libreadline-
     libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev \
     && apt autoremove -y \
     && apt autoclean
-#doing this in case there is an older version of python3 installed
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 \
-    #lsb_release not available on python 3.6 and above, but is required by most debian-based image for pip(3)
-    && ln -s /usr/share/pyshared/lsb_release.py /usr/lib/python3.7/site-packages/lsb_release.py
 RUN pip3 --no-cache-dir install ansible requests

--- a/py23-image/redhat-8/Dockerfile
+++ b/py23-image/redhat-8/Dockerfile
@@ -2,6 +2,13 @@ ARG SPLUNK_PRODUCT=splunk
 FROM ${SPLUNK_PRODUCT}-redhat-8:latest
 USER root
 
-RUN microdnf -y --nodocs install python3
-RUN alternatives --set python /usr/bin/python2
+# INFRA-15385: manual installation of python 3.7 as default distro version is 3.6
+RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
+    && tar xzf Python-3.7.4.tgz \
+    && cd Python-3.7.4 \
+    && ./configure --enable-optimizations --prefix=/usr \
+    && make altinstall \
+    && cd .. \
+    && rm Python-3.7.4.tgz \
+    && rm -r Python-3.7.4
 RUN pip3 -q --no-cache-dir install requests ansible

--- a/py23-image/redhat-8/Dockerfile
+++ b/py23-image/redhat-8/Dockerfile
@@ -2,13 +2,24 @@ ARG SPLUNK_PRODUCT=splunk
 FROM ${SPLUNK_PRODUCT}-redhat-8:latest
 USER root
 
+RUN microdnf -y update \
+    && microdnf -y install make gcc openssl-devel bzip2-devel libffi-devel
 # INFRA-15385: manual installation of python 3.7 as default distro version is 3.6
 RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
     && tar xzf Python-3.7.4.tgz \
     && cd Python-3.7.4 \
     && ./configure --enable-optimizations --prefix=/usr \
-    && make altinstall \
+    && make install \
     && cd .. \
     && rm Python-3.7.4.tgz \
-    && rm -r Python-3.7.4
+    && rm -r Python-3.7.4 \
+    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3.7 get-pip.py \
+    && rm -f get-pip.py \
+    #pip version is not automatically "fixed", unlike debian-based
+    && ln -sf /usr/bin/pip2 /usr/bin/pip \
+    && ln -sf /usr/bin/pip3.7 /usr/bin/pip3
+#microdnf persists metadata which is a problem for removing packages. So have to clean first before removing. 
+RUN microdnf clean all \
+	&& microdnf remove -y gcc make openssl-devel bzip2-devel libffi-devel
 RUN pip3 -q --no-cache-dir install requests ansible


### PR DESCRIPTION
This PR is part of efforts neccessary to completely migrate to python3.
This set of images will use python3.7 as default interpreter for ansible and splunk-orca images will be based off of these images.