### PR TITLE
lsb_release

### DIFF
--- a/py23-image/debian-9/Dockerfile
+++ b/py23-image/debian-9/Dockerfile
@@ -17,7 +17,8 @@ RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
     && rm -r Python-3.7.4 \
     && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && python3.7 get-pip.py \
-    && rm -f get-pip.py
+    && rm -f get-pip.py \
+    && ln -s /usr/share/pyshared/lsb_release.py /usr/lib/python3.7/site-packages/lsb_release.py
 #removing all intermediate dependencies. All the stuff below comes up to 200+MB
 RUN apt-get remove --purge -y gcc make build-essential checkinstall libreadline-gplv2-dev libncursesw5-dev \
     libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev \


### PR DESCRIPTION
this is required for ansible on python3. It's missing from previous PR
see this thread: https://git.splunk.com/projects/TOOLS/repos/orca/pull-requests/2060/overview?commentId=897124