### PR TITLE
Fixing errors with new 8.1.x splunk packages

### DIFF
--- a/splunk/common-files/make-minimal-exclude.py
+++ b/splunk/common-files/make-minimal-exclude.py
@@ -9,7 +9,6 @@ EXCLUDE_V7 = """*-manifest
 */bin/*mongo*
 */3rdparty/Copyright-for-mongo*
 */bin/node*
-*/bin/parsetest*
 */bin/pcregextest*
 */etc/*.lic*
 */etc/anonymizer*
@@ -34,13 +33,15 @@ EXCLUDE_V7 = """*-manifest
 m = re.match(".*splunk-([0-9]+)\.([0-9]+)\.[0-9]+\.?[0-9]?-[0-9a-z]+-Linux-[0-9a-z_-]+.tgz", sys.argv[1])
 
 if m and m.group(1):
-    if m.group(1) == "7":
-        print EXCLUDE_V7
+    print(EXCLUDE_V7)
+    if int(m.group(1)) == 7:
+        print("*/bin/parsetest*")
         if int(m.group(2)) < 3:
-            print "*/etc/apps/framework*"
-            print "*/etc/apps/gettingstarted*"
+            print("*/etc/apps/framework*")
+            print("*/etc/apps/gettingstarted*")
         else:
-            print "*/etc/apps/splunk_metrics_workspace*"
+            print("*/etc/apps/splunk_metrics_workspace*")
     elif int(m.group(1)) > 7:
-        print EXCLUDE_V7
-        print "*/etc/apps/splunk_metrics_workspace*"
+        print("*/etc/apps/splunk_metrics_workspace*")
+        if int(m.group(2)) < 1:
+            print("*/bin/parsetest*")


### PR DESCRIPTION
Some newer Splunk 8.1.x packages are failing to build Docker images due to:
```
Step 10/43 : RUN tar -C /minimal/splunk --strip 1 --exclude-from=/tmp/splunk-minimal-exclude.list -zxf /tmp/splunk.tgz
 ---> Using cache
 ---> 4d01bbd1b77a
Step 11/43 : RUN tar -C /extras/splunk --strip 1 --wildcards --ignore-command-error --files-from=/tmp/splunk-minimal-exclude.list -zxf /tmp/splunk.tgz
 ---> Running in b8d920876954
tar: */bin/parsetest*: Not found in archive
tar: Exiting with failure status due to previous errors
The command '/bin/sh -c tar -C /extras/splunk --strip 1 --wildcards --files-from=/tmp/splunk-minimal-exclude.list -zxf /tmp/splunk.tgz' returned a non-zero code: 2
make: *** [splunk-debian-10] Error 2
```
 
It seems `bin/parsetest` is completely removed in new packages. Tarring the extras dir with this regex is causing tar to questionably fail. I've tried a combination of `--ignore-command-error` and `--ignore-failed-read` but none of those seem to work as how I want :P