### PR TITLE
take version label out of dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ base-centos-7:
 	docker build ${DOCKER_BUILD_FLAGS} -t base-centos-7:${IMAGE_VERSION} ./base/centos-7
 
 base-redhat-8:
-	docker build ${DOCKER_BUILD_FLAGS} -t base-redhat-8:${IMAGE_VERSION} ./base/redhat-8
+	docker build ${DOCKER_BUILD_FLAGS} --label version=${SPLUNK_VERSION} -t base-redhat-8:${IMAGE_VERSION} ./base/redhat-8
 
 base-windows-2016:
 	docker build ${DOCKER_BUILD_FLAGS} -t base-windows-2016:${IMAGE_VERSION} ./base/windows-2016

--- a/base/redhat-8/Dockerfile
+++ b/base/redhat-8/Dockerfile
@@ -20,7 +20,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 LABEL name="splunk" \
       maintainer="support@splunk.com" \
       vendor="splunk" \
-      version="7.3.2" \
       release="1" \
       summary="UBI 8 Docker image of Splunk Enterprise" \
       description="Splunk Enterprise is a platform for operational intelligence. Our software lets you collect, analyze, and act upon the untapped value of big data that your technology infrastructure, security systems, and business applications generate. It gives you insights to drive operational performance and business results."


### PR DESCRIPTION
To ease the pain of having to change version in 2 files when updating splunk version.
Also verified this still pass OpenShift scan since they don't merely scan Dockerfile, but the actual metadata inside the container