### PR TITLE
pinning UBI to 8.0 and don't update packages

### DIFF
--- a/base/redhat-8/Dockerfile
+++ b/base/redhat-8/Dockerfile
@@ -16,7 +16,7 @@
 # the container catalog moved from registry.access.redhat.com to registry.redhat.io
 # So at some point before they deprecate the old registry we have to make sure that
 # we have access to the new registry and change where we pull the ubi image from.
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0-213
 LABEL name="splunk" \
       maintainer="support@splunk.com" \
       vendor="splunk" \

--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -16,7 +16,6 @@
 set -e
 
 # reinstalling local en def for now, removed in minimal image https://bugzilla.redhat.com/show_bug.cgi?id=1665251
-microdnf -y update
 microdnf -y --nodocs install glibc-langpack-en
 
 #Currently there is no access to the UTF-8 char map, the following command is commented out until


### PR DESCRIPTION
splunk/splunk:edge is currently broken because Redhat pushed UBI 8.1 as the latest UBI which contains update to libdnf that breaks microdnf.

This PR pins the UBI to 8.0 and remove update to prevent that from happenning.
I will monitor updates from them and change this back to pull from latest once they publish the fix.
Created this ticket to keep track https://jira.splunk.com/browse/CSPL-173