### PR TITLE
Support for tzdata in UBI redhat images

### DIFF
--- a/base/redhat-8/Dockerfile
+++ b/base/redhat-8/Dockerfile
@@ -16,7 +16,7 @@
 # the container catalog moved from registry.access.redhat.com to registry.redhat.io
 # So at some point before they deprecate the old registry we have to make sure that
 # we have access to the new registry and change where we pull the ubi image from.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0-213
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 LABEL name="splunk" \
       maintainer="support@splunk.com" \
       vendor="splunk" \

--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -15,6 +15,8 @@
 
 set -e
 
+# Per: https://github.com/rpm-software-management/microdnf/issues/50
+mkdir -p /run/user/$UID
 # reinstalling local en def for now, removed in minimal image https://bugzilla.redhat.com/show_bug.cgi?id=1665251
 microdnf -y --nodocs install glibc-langpack-en
 
@@ -25,7 +27,8 @@ microdnf -y --nodocs install glibc-langpack-en
 #We get around the gen above by forcing the language install, and then point to it.
 export LANG=en_US.utf8
 
-microdnf -y --nodocs install wget sudo shadow-utils procps tar
+rpm -e --nodeps tzdata
+microdnf -y --nodocs install wget sudo shadow-utils procps tar tzdata
 #install busybox direct from the multiarch since epel isn't availible yet for redhat8
 wget -O /bin/busybox https://busybox.net/downloads/binaries/1.28.1-defconfig-multiarch/busybox-`arch`
 chmod +x /bin/busybox


### PR DESCRIPTION
Updating redhat image to 8.1 and also fixing issues with tzdata packages. See https://github.com/splunk/docker-splunk/issues/301