### PR TITLE
Bugfix/uf uid gid

### DIFF
--- a/tests/fixtures/pwfile
+++ b/tests/fixtures/pwfile
@@ -1,0 +1,1 @@
+changeme123

--- a/tests/test_docker_splunk.py
+++ b/tests/test_docker_splunk.py
@@ -923,6 +923,44 @@ class TestDockerSplunk(object):
             if cid:
                 self.client.remove_container(cid, v=True, force=True)
 
+    def test_adhoc_1so_splunk_pass4symmkey(self):
+        # Create a splunk container
+        cid = None
+        try:
+            splunk_container_name = generate_random_string()
+            cid = self.client.create_container(self.SPLUNK_IMAGE_NAME, tty=True, ports=[8089], name=splunk_container_name,
+                                               environment={
+                                                            "DEBUG": "true", 
+                                                            "SPLUNK_START_ARGS": "--accept-license",
+                                                            "SPLUNK_PASSWORD": self.password,
+                                                            "SPLUNK_PASS4SYMMKEY": "wubbalubbadubdub"
+                                                        },
+                                               host_config=self.client.create_host_config(port_bindings={8089: ("0.0.0.0",)})
+                                            )
+            cid = cid.get("Id")
+            self.client.start(cid)
+            # Poll for the container to be ready
+            assert self.wait_for_containers(1, name=splunk_container_name)
+            # Check splunkd
+            splunkd_port = self.client.port(cid, 8089)[0]["HostPort"]
+            url = "https://localhost:{}/services/server/info".format(splunkd_port)
+            kwargs = {"auth": ("admin", self.password), "verify": False}
+            status, content = self.handle_request_retry("GET", url, kwargs)
+            assert status == 200
+            # Check the decrypted pass4SymmKey
+            exec_command = self.client.exec_create(cid, "cat /opt/splunk/etc/system/local/server.conf", user="splunk")
+            std_out = self.client.exec_start(exec_command)
+            pass4SymmKey = re.search(r'\[general\].*?pass4SymmKey = (.*?)\n', std_out, flags=re.MULTILINE|re.DOTALL).group(1).strip()
+            exec_command = self.client.exec_create(cid, "/opt/splunk/bin/splunk show-decrypted --value '{}'".format(pass4SymmKey), user="splunk")
+            std_out = self.client.exec_start(exec_command)
+            assert "wubbalubbadubdub" in std_out
+        except Exception as e:
+            self.logger.error(e)
+            raise e
+        finally:
+            if cid:
+                self.client.remove_container(cid, v=True, force=True)
+
     def test_adhoc_1so_splunk_secret_env(self):
         # Create a splunk container
         cid = None
@@ -949,6 +987,44 @@ class TestDockerSplunk(object):
             assert status == 200
             # Check if the created file exists
             exec_command = self.client.exec_create(cid, "cat /opt/splunk/etc/auth/splunk.secret", user="splunk")
+            std_out = self.client.exec_start(exec_command)
+            assert "wubbalubbadubdub" in std_out
+        except Exception as e:
+            self.logger.error(e)
+            raise e
+        finally:
+            if cid:
+                self.client.remove_container(cid, v=True, force=True)
+    
+    def test_adhoc_1uf_splunk_pass4symmkey(self):
+        # Create a splunk container
+        cid = None
+        try:
+            splunk_container_name = generate_random_string()
+            cid = self.client.create_container(self.UF_IMAGE_NAME, tty=True, ports=[8089], name=splunk_container_name,
+                                               environment={
+                                                            "DEBUG": "true", 
+                                                            "SPLUNK_START_ARGS": "--accept-license",
+                                                            "SPLUNK_PASSWORD": self.password,
+                                                            "SPLUNK_PASS4SYMMKEY": "wubbalubbadubdub"
+                                                        },
+                                               host_config=self.client.create_host_config(port_bindings={8089: ("0.0.0.0",)})
+                                            )
+            cid = cid.get("Id")
+            self.client.start(cid)
+            # Poll for the container to be ready
+            assert self.wait_for_containers(1, name=splunk_container_name)
+            # Check splunkd
+            splunkd_port = self.client.port(cid, 8089)[0]["HostPort"]
+            url = "https://localhost:{}/services/server/info".format(splunkd_port)
+            kwargs = {"auth": ("admin", self.password), "verify": False}
+            status, content = self.handle_request_retry("GET", url, kwargs)
+            assert status == 200
+            # Check the decrypted pass4SymmKey
+            exec_command = self.client.exec_create(cid, "cat /opt/splunkforwarder/etc/system/local/server.conf", user="splunk")
+            std_out = self.client.exec_start(exec_command)
+            pass4SymmKey = re.search(r'\[general\].*?pass4SymmKey = (.*?)\n', std_out, flags=re.MULTILINE|re.DOTALL).group(1).strip()
+            exec_command = self.client.exec_create(cid, "/opt/splunkforwarder/bin/splunk show-decrypted --value '{}'".format(pass4SymmKey), user="splunk")
             std_out = self.client.exec_start(exec_command)
             assert "wubbalubbadubdub" in std_out
         except Exception as e:
@@ -2485,6 +2561,48 @@ class TestDockerSplunk(object):
                 os.remove(os.path.join(SCENARIOS_DIR, "defaults", "default.yml"))
             except OSError as e:
                 pass
+    
+    def test_adhoc_1cm_idxc_pass4symmkey(self):
+        # Create the container
+        cid = None
+        try:
+            splunk_container_name = generate_random_string()
+            cid = self.client.create_container(self.SPLUNK_IMAGE_NAME, tty=True, ports=[8089], name=splunk_container_name,
+                                            environment={
+                                                            "DEBUG": "true", 
+                                                            "SPLUNK_START_ARGS": "--accept-license",
+                                                            "SPLUNK_PASSWORD": self.password,
+                                                            "SPLUNK_ROLE": "splunk_cluster_master",
+                                                            "SPLUNK_INDEXER_URL": "idx1",
+                                                            "SPLUNK_IDXC_PASS4SYMMKEY": "keepsummerbeingliketotallystokedaboutlikethegeneralvibeandstuff",
+                                                            "SPLUNK_IDXC_LABEL": "keepsummersafe",
+                                                        },
+                                            host_config=self.client.create_host_config(port_bindings={8089: ("0.0.0.0",)})
+                                            )
+            cid = cid.get("Id")
+            self.client.start(cid)
+            # Poll for the container to be ready
+            assert self.wait_for_containers(1, name=splunk_container_name)
+            # Check splunkd
+            splunkd_port = self.client.port(cid, 8089)[0]["HostPort"]
+            url = "https://localhost:{}/services/server/info".format(splunkd_port)
+            kwargs = {"auth": ("admin", self.password), "verify": False}
+            status, content = self.handle_request_retry("GET", url, kwargs)
+            assert status == 200
+            # Check if the cluster label and pass4SymmKey line up
+            exec_command = self.client.exec_create(cid, "cat /opt/splunk/etc/system/local/server.conf", user="splunk")
+            std_out = self.client.exec_start(exec_command)
+            assert "cluster_label = keepsummersafe" in std_out
+            pass4SymmKey = re.search(r'\[clustering\].*?pass4SymmKey = (.*?)\n', std_out, flags=re.MULTILINE|re.DOTALL).group(1).strip()
+            exec_command = self.client.exec_create(cid, "/opt/splunk/bin/splunk show-decrypted --value '{}'".format(pass4SymmKey), user="splunk")
+            std_out = self.client.exec_start(exec_command)
+            assert "keepsummerbeingliketotallystokedaboutlikethegeneralvibeandstuff" in std_out
+        except Exception as e:
+            self.logger.error(e)
+            raise e
+        finally:
+            if cid:
+                self.client.remove_container(cid, v=True, force=True)
 
     def test_compose_1cm_smartstore(self):
         # Generate default.yml

--- a/uf/common-files/Dockerfile
+++ b/uf/common-files/Dockerfile
@@ -36,6 +36,12 @@ COPY uf/common-files/apps ${SPLUNK_HOME}-etc/apps/
 FROM ${SPLUNK_BASE_IMAGE}:latest as bare
 LABEL maintainer="support@splunk.com"
 
+# Currently kubernetes only accepts UID and not USER field to
+# start a container as a particular user. So we create Splunk
+# user with pre-determined UID.
+ARG UID=41812
+ARG GID=41812
+
 ENV SPLUNK_HOME=/opt/splunkforwarder \
     SPLUNK_GROUP=splunk \
     SPLUNK_USER=splunk
@@ -44,8 +50,8 @@ ENV SPLUNK_HOME=/opt/splunkforwarder \
 COPY [ "splunk/common-files/updateetc.sh", "/sbin/"]
 
 # Setup users and groups
-RUN groupadd -r ${SPLUNK_GROUP} \
-    && useradd -r -m -g ${SPLUNK_GROUP} ${SPLUNK_USER} \
+RUN groupadd -r -g ${GID} ${SPLUNK_GROUP} \
+    && useradd -r -m -u ${UID} -g ${GID} ${SPLUNK_USER} \
     && chmod 755 /sbin/updateetc.sh
 
 # Copy files from package


### PR DESCRIPTION
Adding the UID/GID for the `splunk` user when using the `splunk/universalforwarder` container per https://github.com/splunk/docker-splunk/issues/319. It seems like we just forgot to do this because it's a separate image.

Also adding a bunch of tests for misc features in splunk-ansible