### PR TITLE
Updating image for upgrade test

### DIFF
--- a/tests/test_docker_splunk.py
+++ b/tests/test_docker_splunk.py
@@ -42,7 +42,7 @@ LOGGER.addHandler(file_handler)
 
 global platform
 platform = "debian-9"
-OLD_SPLUNK_VERSION = "7.3.2"
+OLD_SPLUNK_VERSION = "7.3.4"
 
 
 def generate_random_string():


### PR DESCRIPTION
Per https://github.com/splunk/docker-splunk/issues/209#issuecomment-596771600, the enterprise trial license is broken on some older images. While we figure out what to do with that, I'm updating this test to use a different origin image.