### PR TITLE
Updating to latest redhat ubi-minimal

### DIFF
--- a/base/redhat-8/Dockerfile
+++ b/base/redhat-8/Dockerfile
@@ -16,7 +16,7 @@
 # the container catalog moved from registry.access.redhat.com to registry.redhat.io
 # So at some point before they deprecate the old registry we have to make sure that
 # we have access to the new registry and change where we pull the ubi image from.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-328
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 LABEL name="splunk" \
       maintainer="support@splunk.com" \
       vendor="splunk" \


### PR DESCRIPTION
We're a couple versions behind after pinning the tag to `8.1-328` -- just going to use `8.1` now that it's been updated: https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/ubi-minimal