### PR TITLE
Limiting ansible-playbook to localhost only

### DIFF
--- a/splunk/common-files/entrypoint.sh
+++ b/splunk/common-files/entrypoint.sh
@@ -80,7 +80,7 @@ start_and_exit() {
 	sh -c "echo 'starting' > ${CONTAINER_ARTIFACT_DIR}/splunk-container.state"
 	setup
 	prep_ansible
-	ansible-playbook $ANSIBLE_EXTRA_FLAGS -i inventory/environ.py site.yml
+	ansible-playbook $ANSIBLE_EXTRA_FLAGS -i inventory/environ.py -l localhost site.yml
 }
 
 start() {
@@ -91,7 +91,7 @@ start() {
 
 configure_multisite() {
 	prep_ansible
-	ansible-playbook $ANSIBLE_EXTRA_FLAGS -i inventory/environ.py multisite.yml
+	ansible-playbook $ANSIBLE_EXTRA_FLAGS -i inventory/environ.py -l localhost multisite.yml
 }
 
 restart(){
@@ -99,7 +99,7 @@ restart(){
 	sh -c "echo 'restarting' > ${CONTAINER_ARTIFACT_DIR}/splunk-container.state"
 	prep_ansible
 	${SPLUNK_HOME}/bin/splunk stop 2>/dev/null || true
-	ansible-playbook -i inventory/environ.py start.yml
+	ansible-playbook -i inventory/environ.py -l localhost start.yml
 	watch_for_failure
 }
 

--- a/uf/common-files/entrypoint.sh
+++ b/uf/common-files/entrypoint.sh
@@ -79,7 +79,7 @@ start_and_exit() {
 	sh -c "echo 'starting' > ${CONTAINER_ARTIFACT_DIR}/splunk-container.state"
 	setup
 	prep_ansible
-	ansible-playbook $ANSIBLE_EXTRA_FLAGS -i inventory/environ.py site.yml
+	ansible-playbook $ANSIBLE_EXTRA_FLAGS -i inventory/environ.py -l localhost site.yml
 }
 
 start() {
@@ -93,7 +93,7 @@ restart(){
 	sh -c "echo 'restarting' > ${CONTAINER_ARTIFACT_DIR}/splunk-container.state"
 	prep_ansible
 	${SPLUNK_HOME}/bin/splunk stop 2>/dev/null || true
-	ansible-playbook -i inventory/environ.py start.yml
+	ansible-playbook -i inventory/environ.py -l localhost start.yml
 	watch_for_failure
 }
 


### PR DESCRIPTION
This should be a pretty inane change, but I've been experimenting with how to run `splunk-ansible` site.yml remotely, and I don't want to break any functionality here.