### PR TITLE
Add CODEOWNERS to repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Code owners are automatically requested for review when someone opens a
+# pull request modifying code that they own.
+# See: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Note: Each line is a file pattern followed by one or more owners.
+#       Order matters: The last matching pattern has the most precedence.
+
+# Default owners for everything in docker-splunk:
+# *       @splunk/if-01
+*       @nwang @alishamayor @arctan5x @lephino @jrigassio-splunk @jmeixensperger @hendolim @jonathan-vega-splunk
+
+# Docs-only pull requests:
+/docs/  @alishamayor @nwang


### PR DESCRIPTION
The CODEOWNERS file sets file owners and therefore default reviewers for any pull request modifying those files. See [About code owners](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) for more.

I've just set the default catch-all for now, but we can further specify code owners/reviewers per directory or file type.
e.g. Setting docs-only updates to just Nelson and I for now to avoid spamming everyone.
