### PR TITLE
Adding callout to both --volume and --mount

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -51,17 +51,37 @@ When starting the docker container, the `default.yml` can be mounted in `/tmp/de
 
 Environment variables specified at runtime will take precedence over anything defined in `default.yml`.
 ```bash
-# Volume-mounting option
+# Volume-mounting option using --volumes/-v flag
 $ docker run -d -p 8000:8000 -e "SPLUNK_PASSWORD=<password>" \
              -e "SPLUNK_START_ARGS=--accept-license" \
-             -v default.yml:/tmp/defaults/default.yml \
+             -v "$(pwd)/default.yml:/tmp/defaults/default.yml" \
+             splunk/splunk:latest
+
+# Volume-mounting option using --mount flag
+$ docker run -d -p 8000:8000 -e "SPLUNK_PASSWORD=<password>" \
+             -e "SPLUNK_START_ARGS=--accept-license" \
+             --mount type=bind,source="$(pwd)"/default.yml,target=/tmp/defaults/default.yml
              splunk/splunk:latest
 
 # URL option
-$ docker run -d -p 8000:8000 -v -e "SPLUNK_PASSWORD=<password>" \
+$ docker run -d -p 8000:8000 -e "SPLUNK_PASSWORD=<password>" \
              -e "SPLUNK_START_ARGS=--accept-license" \
              -e "SPLUNK_DEFAULTS_URL=http://company.net/path/to/default.yml" \
              splunk/splunk:latest
+```
+
+Additionally, note that you do not need to supply the full `default.yml` if you only choose to modify a portion of how Splunk Enterprise is configured upon boot. For instance, if you wish to take advantage of the ability to write conf files through the `splunk.conf` key, the full `default.yml` passed in will simply look like the following:
+```
+splunk:
+  conf:
+    - key: indexes
+      value:
+        directory: /opt/splunk/etc/system/local
+        content:
+          test:
+            homePath: $SPLUNK_DB/test/db
+            coldPath: $SPLUNK_DB/test/colddb
+            thawedPath: $SPLUNK_DB/test/thaweddb
 ```
 
 ### Configuration specs for default.yml

--- a/docs/advanced/APP_INSTALL.md
+++ b/docs/advanced/APP_INSTALL.md
@@ -16,15 +16,19 @@ App installation can be done a variety of ways: either through a file/directory 
 If you have a local directory that follows the proper Splunk apps model, you can mount this entire path to the container at runtime.
 
 For instance, take the following app `splunk_app_example`:
-```
+```bash
 $ find . -type f
 ./splunk_app_example/default/app.conf
 ./splunk_app_example/metadata/default.meta
 ```
 
 We can bind-mount this upon container start and use it as a regular Splunk app:
-```
-$ docker run -it -v ./splunk_app_example:/opt/splunk/etc/apps/splunk_app_example/ --name so1 --hostname so1 -p 8000:8000 -e "SPLUNK_PASSWORD=<password>" -e "SPLUNK_START_ARGS=--accept-license" -it splunk/splunk:latest
+```bash
+# Volume-mounting option using --volumes/-v flag
+$ docker run -it -v "$(pwd)/splunk_app_example:/opt/splunk/etc/apps/splunk_app_example/" --name so1 --hostname so1 -p 8000:8000 -e "SPLUNK_PASSWORD=<password>" -e "SPLUNK_START_ARGS=--accept-license" -it splunk/splunk:latest
+
+# Volume-mounting option using --mount flag
+$ docker run -it --mount type=bind,source="$(pwd)"/splunk_app_example,target=/opt/splunk/etc/apps/splunk_app_example/ --name so1 --hostname so1 -p 8000:8000 -e "SPLUNK_PASSWORD=<password>" -e "SPLUNK_START_ARGS=--accept-license" -it splunk/splunk:latest
 ```
 
 You should be able to view the `splunk_app_example` in SplunkWeb after the container successfully finished provisioning.


### PR DESCRIPTION
Fixes #377 

There actually weren't many spots where `-v/--volume` were used, but I added both options for usability. Thanks for catching this @edumserrano!