### PR TITLE
[fix] Add commands for proper use of diag --upload feature

### DIFF
--- a/base/centos-7/install.sh
+++ b/base/centos-7/install.sh
@@ -27,6 +27,8 @@ tar -xf /usr/bin/scloud.tar.gz -C /usr/bin/
 rm /usr/bin/scloud.tar.gz
 
 cd /bin
+ln -s busybox clear
+ln -s busybox find
 ln -s busybox killall
 ln -s busybox netstat
 ln -s busybox nslookup

--- a/base/centos-7/install.sh
+++ b/base/centos-7/install.sh
@@ -27,8 +27,6 @@ tar -xf /usr/bin/scloud.tar.gz -C /usr/bin/
 rm /usr/bin/scloud.tar.gz
 
 cd /bin
-ln -s busybox clear
-ln -s busybox find
 ln -s busybox killall
 ln -s busybox netstat
 ln -s busybox nslookup

--- a/base/debian-10/install.sh
+++ b/base/debian-10/install.sh
@@ -43,6 +43,8 @@ tar -xf /usr/bin/scloud.tar.gz -C /usr/bin/
 rm /usr/bin/scloud.tar.gz
 
 cd /bin
+ln -s busybox clear
+ln -s busybox find
 ln -s busybox killall
 ln -s busybox netstat
 ln -s busybox nslookup

--- a/base/debian-9/install.sh
+++ b/base/debian-9/install.sh
@@ -43,6 +43,8 @@ tar -xf /usr/bin/scloud.tar.gz -C /usr/bin/
 rm /usr/bin/scloud.tar.gz
 
 cd /bin
+ln -s busybox clear
+ln -s busybox find
 ln -s busybox diff
 ln -s busybox killall
 ln -s busybox netstat

--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -50,6 +50,8 @@ tar -xf /usr/bin/scloud.tar.gz -C /usr/bin/
 rm /usr/bin/scloud.tar.gz
 
 cd /bin
+ln -s busybox clear
+ln -s busybox find
 ln -s python2 python || true
 ln -s busybox diff || true
 ln -s busybox hostname || true

--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -50,8 +50,8 @@ tar -xf /usr/bin/scloud.tar.gz -C /usr/bin/
 rm /usr/bin/scloud.tar.gz
 
 cd /bin
-ln -s busybox clear
-ln -s busybox find
+ln -s busybox clear || true
+ln -s busybox find || true
 ln -s python2 python || true
 ln -s busybox diff || true
 ln -s busybox hostname || true


### PR DESCRIPTION
Splunk's newish feature to upload diags to support requires the shell command "clear" this PR also adds the find command