### PR TITLE
Changing etc backup directory so its not tied to SPLUNK_HOME

### DIFF
--- a/splunk/common-files/updateetc.sh
+++ b/splunk/common-files/updateetc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Splunk
+# Copyright 2018-2020 Splunk
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
 # limitations under the License.
 #
 
-if [[ -f "${SPLUNK_HOME}-etc/splunk.version" ]]; then
-	IMAGE_VERSION_SHA=`cat ${SPLUNK_HOME}-etc/splunk.version | sha512sum`
+SPLUNK_ETC_BAK="${SPLUNK_ETC_BAK:-/opt/splunk-etc}"
+
+if [[ -f "${SPLUNK_ETC_BAK}/splunk.version" ]]; then
+	IMAGE_VERSION_SHA=`cat ${SPLUNK_ETC_BAK}/splunk.version | sha512sum`
 
 	if [[ -f "${SPLUNK_HOME}/etc/splunk.version" ]]; then
 		ETC_VERSION_SHA=`cat ${SPLUNK_HOME}/etc/splunk.version | sha512sum`
@@ -24,6 +26,6 @@ if [[ -f "${SPLUNK_HOME}-etc/splunk.version" ]]; then
 
 	if [[ "x${IMAGE_VERSION_SHA}" != "x${ETC_VERSION_SHA}" ]]; then
     	echo Updating ${SPLUNK_HOME}/etc
-    	(cd ${SPLUNK_HOME}-etc; tar cf - *) | (cd ${SPLUNK_HOME}/etc; tar xf -)
+    	(cd ${SPLUNK_ETC_BAK}; tar cf - *) | (cd ${SPLUNK_HOME}/etc; tar xf -)
 	fi
 fi

--- a/uf/common-files/Dockerfile
+++ b/uf/common-files/Dockerfile
@@ -47,7 +47,7 @@ ENV SPLUNK_HOME=/opt/splunkforwarder \
     SPLUNK_USER=splunk
 
 # Simple script used to populate/upgrade splunk/etc directory
-COPY [ "splunk/common-files/updateetc.sh", "/sbin/"]
+COPY [ "uf/common-files/updateetc.sh", "/sbin/"]
 
 # Setup users and groups
 RUN groupadd -r -g ${GID} ${SPLUNK_GROUP} \

--- a/uf/common-files/updateetc.sh
+++ b/uf/common-files/updateetc.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2018-2020 Splunk
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+SPLUNK_ETC_BAK="${SPLUNK_ETC_BAK:-/opt/splunkforwarder-etc}"
+
+if [[ -f "${SPLUNK_ETC_BAK}/splunk.version" ]]; then
+	IMAGE_VERSION_SHA=`cat ${SPLUNK_ETC_BAK}/splunk.version | sha512sum`
+
+	if [[ -f "${SPLUNK_HOME}/etc/splunk.version" ]]; then
+		ETC_VERSION_SHA=`cat ${SPLUNK_HOME}/etc/splunk.version | sha512sum`
+	fi
+
+	if [[ "x${IMAGE_VERSION_SHA}" != "x${ETC_VERSION_SHA}" ]]; then
+    	echo Updating ${SPLUNK_HOME}/etc
+    	(cd ${SPLUNK_ETC_BAK}; tar cf - *) | (cd ${SPLUNK_HOME}/etc; tar xf -)
+	fi
+fi


### PR DESCRIPTION
This should be a small fix per https://github.com/splunk/docker-splunk/issues/408 - if SPLUNK_HOME is not the default `/opt/splunk`, we may not want to couple the etc stored in the image.