### PR TITLE
Centos8 ansible execution fix

### DIFF
--- a/py23-image/centos-8/Dockerfile
+++ b/py23-image/centos-8/Dockerfile
@@ -27,4 +27,4 @@ RUN yum remove -y --setopt=tsflags=noscripts gcc openssl-devel bzip2-devel libff
     && yum autoremove -y \
     && yum clean all
 RUN pip3 --no-cache-dir install ansible requests
-RUN pip --no-cache-dir install pyyaml
+RUN pip --no-cache-dir install pyyaml requests

--- a/py23-image/centos-8/Dockerfile
+++ b/py23-image/centos-8/Dockerfile
@@ -27,3 +27,4 @@ RUN yum remove -y --setopt=tsflags=noscripts gcc openssl-devel bzip2-devel libff
     && yum autoremove -y \
     && yum clean all
 RUN pip3 --no-cache-dir install ansible requests
+RUN pip --no-cache-dir install pyyaml

--- a/py23-image/centos-8/Dockerfile
+++ b/py23-image/centos-8/Dockerfile
@@ -26,5 +26,5 @@ RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
 RUN yum remove -y --setopt=tsflags=noscripts gcc openssl-devel bzip2-devel libffi-devel \
     && yum autoremove -y \
     && yum clean all
-RUN pip3 --no-cache-dir install ansible requests
-RUN pip --no-cache-dir install pyyaml requests
+RUN pip3 --no-cache-dir install ansible requests \
+    && pip --no-cache-dir install pyyaml requests


### PR DESCRIPTION
For some reason, ansible expects its support libs to exist for python2 (might involve how we are setting up the default interpreter).

I'm including these packages for now to resolve these issues. I have tested both splunk/uf images and the subsequent splunk-orca images built on top of them. My testing has also covered shc and idc.