### PR TITLE
Fixing centos-7 ulimits

### DIFF
--- a/base/centos-7/install.sh
+++ b/base/centos-7/install.sh
@@ -41,6 +41,9 @@ echo "
 ## Allows people in group sudo to run all commands
 %sudo  ALL=(ALL)       ALL" >> /etc/sudoers
 
+# Remove nproc limits
+rm -rf /etc/security/limits.d/20-nproc.conf
+
 # Clean
 yum clean all
 rm -rf /install.sh /anaconda-post.log /var/log/anaconda/*

--- a/tests/test_single_splunk_image.py
+++ b/tests/test_single_splunk_image.py
@@ -81,12 +81,31 @@ class TestDockerSplunk(Executor):
             time.sleep(5)
             # If the container is still running, we should be able to exec inside
             # Check that the version returns successfully for multiple users
-            exec_command = self.client.exec_create(cid, "scloud version", user="splunk")
+            for user in ["splunk", "ansible"]:
+                exec_command = self.client.exec_create(cid, "scloud version", user=user)
+                std_out = self.client.exec_start(exec_command)
+                assert "scloud version " in std_out
+        except Exception as e:
+            self.logger.error(e)
+            raise e
+        finally:
+            if cid:
+                self.client.remove_container(cid, v=True, force=True)
+
+    def test_splunk_ulimit(self):
+        cid = None
+        try:
+            # Run container
+            cid = self.client.create_container(self.SPLUNK_IMAGE_NAME, tty=True, command="no-provision")
+            cid = cid.get("Id")
+            self.client.start(cid)
+            # Wait a bit
+            time.sleep(5)
+            # If the container is still running, we should be able to exec inside
+            # Check that nproc limits are unlimited
+            exec_command = self.client.exec_create(cid, "sudo -u splunk bash -c 'ulimit -u'")
             std_out = self.client.exec_start(exec_command)
-            assert "scloud version " in std_out
-            exec_command = self.client.exec_create(cid, "scloud version", user="ansible")
-            std_out = self.client.exec_start(exec_command)
-            assert "scloud version " in std_out
+            assert "unlimited" in std_out
         except Exception as e:
             self.logger.error(e)
             raise e
@@ -2635,12 +2654,31 @@ disabled = 1''' in std_out
             time.sleep(5)
             # If the container is still running, we should be able to exec inside
             # Check that the version returns successfully for multiple users
-            exec_command = self.client.exec_create(cid, "scloud version", user="splunk")
+            for user in ["splunk", "ansible"]:
+                exec_command = self.client.exec_create(cid, "scloud version", user=user)
+                std_out = self.client.exec_start(exec_command)
+                assert "scloud version " in std_out
+        except Exception as e:
+            self.logger.error(e)
+            raise e
+        finally:
+            if cid:
+                self.client.remove_container(cid, v=True, force=True)
+
+    def test_uf_ulimit(self):
+        cid = None
+        try:
+            # Run container
+            cid = self.client.create_container(self.UF_IMAGE_NAME, tty=True, command="no-provision")
+            cid = cid.get("Id")
+            self.client.start(cid)
+            # Wait a bit
+            time.sleep(5)
+            # If the container is still running, we should be able to exec inside
+            # Check that nproc limits are unlimited
+            exec_command = self.client.exec_create(cid, "sudo -u splunk bash -c 'ulimit -u'")
             std_out = self.client.exec_start(exec_command)
-            assert "scloud version " in std_out
-            exec_command = self.client.exec_create(cid, "scloud version", user="ansible")
-            std_out = self.client.exec_start(exec_command)
-            assert "scloud version " in std_out
+            assert "unlimited" in std_out
         except Exception as e:
             self.logger.error(e)
             raise e


### PR DESCRIPTION
This seems to only be affecting Centos 7 images. But I'm seeing:
```
$ docker run -d -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_PASSWORD=helloworld splunk-centos-7:latest no-provision
6487e7c91d1b6584c4a01ddc9ec06caf17c29ca5082dc352bc7db860523ad6ec

$ docker exec -it 6487e7c91d1b6584c4a01ddc9ec06caf17c29ca5082dc352bc7db860523ad6ec bash
[ansible@6487e7c91d1b splunk]$ whoami
ansible
[ansible@6487e7c91d1b splunk]$ ulimit -u
unlimited

$ docker exec -it --user splunk 6487e7c91d1b6584c4a01ddc9ec06caf17c29ca5082dc352bc7db860523ad6ec bash
[splunk@6487e7c91d1b splunk]$ whoami
splunk
[splunk@6487e7c91d1b splunk]$ ulimit -u
unlimited

$ docker exec -it  6487e7c91d1b6584c4a01ddc9ec06caf17c29ca5082dc352bc7db860523ad6ec bash
[ansible@6487e7c91d1b splunk]$ ulimit -u
unlimited
[ansible@6487e7c91d1b splunk]$ sudo -u splunk bash
[splunk@6487e7c91d1b splunk]$ ulimit -u
4096
```