### PR TITLE
feat(healthcheck): Improve active health check

### DIFF
--- a/splunk/common-files/Dockerfile
+++ b/splunk/common-files/Dockerfile
@@ -94,6 +94,10 @@ ENV SPLUNK_ROLE=splunk_standalone \
 
 USER root
 
+ARG GOSS_VER=v0.3.15
+RUN curl -fsSL https://goss.rocks/install | sh
+COPY [ "splunk/common-files/goss.yml", "/etc/" ]
+
 COPY [ "splunk/common-files/entrypoint.sh", "splunk/common-files/createdefaults.py", "splunk/common-files/checkstate.sh", "/sbin/" ]
 COPY splunk-ansible ${SPLUNK_ANSIBLE_HOME}
 
@@ -115,6 +119,6 @@ RUN sed -i -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL\nans
     && chmod 755 /sbin/entrypoint.sh /sbin/createdefaults.py /sbin/checkstate.sh
 
 USER ${ANSIBLE_USER}
-HEALTHCHECK --interval=30s --timeout=30s --start-period=3m --retries=5 CMD /sbin/checkstate.sh || exit 1
+HEALTHCHECK --interval=30s --timeout=30s --start-period=3m --retries=5  CMD curl -s --fail http://localhost:9000/healthz || exit 1
 ENTRYPOINT [ "/sbin/entrypoint.sh" ]
 CMD [ "start-service" ]

--- a/splunk/common-files/checkstate.sh
+++ b/splunk/common-files/checkstate.sh
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+#NOTE: This script is no longer the prefered way of validation of container health
+#And remains as it is referenced by splunk-operator until the dependency can be removed
+
 #This script is used to retrieve and report the state of the container
 #Although not actively in the container, it can be used to check the health
 #of the splunk instance
@@ -23,22 +26,8 @@
 # health results
 
 if [[ "" == "$NO_HEALTHCHECK" ]]; then
-    if [[ "false" == "$SPLUNKD_SSL_ENABLE" ]]; then
-      SCHEME="http"
-	else
-      SCHEME="https"
-    fi
-	#If NO_HEALTHCHECK is NOT defined, then we want the healthcheck
-	state="$(< $CONTAINER_ARTIFACT_DIR/splunk-container.state)"
-
-	case "$state" in
-	running|started)
-	    curl -m 30 -f -k $SCHEME://localhost:8089/
-	    exit $?
-	;;
-	*)
-	    exit 1
-	esac
+	goss -g /etc/goss.yml v
+	exit $?
 else
 	#If NO_HEALTHCHECK is defined, ignore the healthcheck
 	exit 0

--- a/splunk/common-files/entrypoint.sh
+++ b/splunk/common-files/entrypoint.sh
@@ -76,7 +76,15 @@ start_and_exit() {
 	then
 		echo "WARNING: No password ENV var.  Stack may fail to provision if splunk.password is not set in ENV or a default.yml"
 	fi
+	: ${SPLUNK_CERT_PREFIX:=https}
 	sh -c "echo 'starting' > ${CONTAINER_ARTIFACT_DIR}/splunk-container.state"
+	if command -v goss &> /dev/null
+	then
+		if [[ "" == "$NO_HEALTHCHECK" ]]
+			echo starting goss
+			goss -g /etc/goss.yml serve --format json --listen-addr 0.0.0.0:9000 >/dev/null 2>/dev/null &
+		fi
+	fi
 	setup
 	prep_ansible
 	ansible-playbook $ANSIBLE_EXTRA_FLAGS -i inventory/environ.py -l localhost site.yml

--- a/splunk/common-files/entrypoint.sh
+++ b/splunk/common-files/entrypoint.sh
@@ -81,6 +81,7 @@ start_and_exit() {
 	if command -v goss &> /dev/null
 	then
 		if [[ "" == "$NO_HEALTHCHECK" ]]
+		then
 			echo starting goss
 			goss -g /etc/goss.yml serve --format json --listen-addr 0.0.0.0:9000 >/dev/null 2>/dev/null &
 		fi

--- a/splunk/common-files/goss.yml
+++ b/splunk/common-files/goss.yml
@@ -1,0 +1,35 @@
+http:
+  {{getEnv "SPLUNK_CERT_PREFIX" "https"}}://127.0.0.1:8089:
+    status: 200
+    allow-insecure: true
+{{if .Env.SPLUNK_ROLE | regexMatch "splunk_standalone|splunk_search_head|splunk_deployer|splunk_license_master|splunk_cluster_master|splunk_heavy_forwarder"}}
+{{if getEnv "SPLUNK_HTTP_ENABLESSL" "false" | regexMatch "true"}}
+  https://127.0.0.1:8000:
+    allow-insecure: true    
+{{else}}
+  http://127.0.0.1:8000:
+{{end}}
+    no-follow-redirects: true
+    status: 303
+{{end}}
+{{if .Env.SPLUNK_ROLE | regexMatch "splunk_standalone|splunk_indexer"}}
+{{if getEnv "SPLUNK_HEC_SSL" "true" | regexMatch "false"}}
+  http://127.0.0.1:8088/services/collector/health:
+{{else}}
+  https://127.0.0.1:8088/services/collector/health:
+    allow-insecure: true    
+{{end}}
+    status: 200
+{{end}}
+{{if .Env.SPLUNK_ROLE | regexMatch "splunk_indexer"}}
+port:
+  tcp:9997:
+    listening: true
+    ip:
+    - 0.0.0.0    
+{{end}}
+file:
+  {{.Env.CONTAINER_ARTIFACT_DIR}}/splunk-container.state:
+    exists: true
+    contains:
+        - "/running|started/"


### PR DESCRIPTION
Replace the existing checkstate.sh file with a goss based liveness check. This is more friendly for podman and k8s deployments and more accurate

Note this PR depends on #438 