### PR TITLE
Converting redhat + debian platforms to py3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ executors:
   py3:
     docker:
       - image: cimg/python:3.7
-  circleci_medium:
+  circleci_large:
     machine:
       image: ubuntu-1604:201903-01
-    resource_class: medium
+    resource_class: large
   circleci_xlarge:
     machine:
       image: ubuntu-1604:201903-01
@@ -72,7 +72,7 @@ jobs:
           whitelist: /root/project/clair-whitelist.yml
 
   test_redhat_8_small:
-    executor: circleci_medium
+    executor: circleci_large
     steps:
       - checkout
       - attach_workspace:
@@ -136,7 +136,7 @@ jobs:
           path: test-results
 
   test_debian_10_small:
-    executor: circleci_medium
+    executor: circleci_large
     steps:
       - checkout
       - attach_workspace:

--- a/base/centos-7/Dockerfile
+++ b/base/centos-7/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ FROM centos:7
 LABEL maintainer="support@splunk.com"
 
 ARG SCLOUD_URL
-ENV SCLOUD_URL ${SCLOUD_URL}
+ENV SCLOUD_URL=${SCLOUD_URL}
 
 COPY install.sh /install.sh
 RUN /install.sh && rm -rf /install.sh

--- a/base/centos-7/install.sh
+++ b/base/centos-7/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018-2020 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,4 +46,4 @@ rm -rf /etc/security/limits.d/20-nproc.conf
 
 # Clean
 yum clean all
-rm -rf /install.sh /anaconda-post.log /var/log/anaconda/*
+rm -rf /anaconda-post.log /var/log/anaconda/*

--- a/base/centos-8/Dockerfile
+++ b/base/centos-8/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ FROM centos:8
 LABEL maintainer="support@splunk.com"
 
 ARG SCLOUD_URL
-ENV SCLOUD_URL ${SCLOUD_URL}
+ENV SCLOUD_URL=${SCLOUD_URL}
 
 COPY install.sh /install.sh
 RUN /install.sh && rm -rf /install.sh

--- a/base/centos-8/install.sh
+++ b/base/centos-8/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018-2020 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,4 +52,4 @@ ln -s /bin/python3 /bin/python
 
 # Clean
 yum clean all
-rm -rf /install.sh /anaconda-post.log /var/log/anaconda/*
+rm -rf /anaconda-post.log /var/log/anaconda/*

--- a/base/debian-10/Dockerfile
+++ b/base/debian-10/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@ FROM debian:buster-slim
 LABEL maintainer="support@splunk.com"
 
 ARG SCLOUD_URL
-ENV SCLOUD_URL ${SCLOUD_URL}
-
-ENV DEBIAN_FRONTEND=noninteractive
+ENV SCLOUD_URL=${SCLOUD_URL} \
+    DEBIAN_FRONTEND=noninteractive \
+    PYTHON_VERSION=3.7.9
 
 COPY install.sh /install.sh
 RUN /install.sh && rm -rf /install.sh

--- a/base/debian-10/install.sh
+++ b/base/debian-10/install.sh
@@ -32,7 +32,8 @@ ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 # Install utility packages
 apt-get install -y --no-install-recommends curl sudo libgssapi-krb5-2 busybox procps acl gcc make \
                                            libffi-dev libssl-dev make build-essential libbz2-dev \
-                                           wget xz-utils ca-certificates zlib1g-dev python3-apt
+                                           wget xz-utils ca-certificates zlib1g-dev python3-apt \
+                                           p11-kit
 
 # Install Python and necessary packages
 PY_SHORT=${PYTHON_VERSION%.*}
@@ -48,9 +49,9 @@ ln -sf /usr/bin/python${PY_SHORT} /usr/bin/python
 ln -sf /usr/bin/pip${PY_SHORT} /usr/bin/pip
 # For ansible apt module
 cd /tmp
-apt-get download python3-apt=1.8.4.2
-dpkg -x python3-apt_1.8.4.2_amd64.deb python3-apt
-rm python3-apt_1.8.4.2_amd64.deb
+apt-get download python3-apt=1.8.4.3
+dpkg -x python3-apt_1.8.4.3_amd64.deb python3-apt
+rm python3-apt_1.8.4.3_amd64.deb
 cp -r /tmp/python3-apt/usr/lib/python3/dist-packages/* /usr/lib/python${PY_SHORT}/site-packages/
 cd /usr/lib/python${PY_SHORT}/site-packages/
 cp apt_pkg.cpython-37m-x86_64-linux-gnu.so apt_pkg.so

--- a/base/debian-9/Dockerfile
+++ b/base/debian-9/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@ FROM debian:stretch-slim
 LABEL maintainer="support@splunk.com"
 
 ARG SCLOUD_URL
-ENV SCLOUD_URL ${SCLOUD_URL}
-
-ENV DEBIAN_FRONTEND=noninteractive
+ENV SCLOUD_URL=${SCLOUD_URL} \
+    DEBIAN_FRONTEND=noninteractive \
+    PYTHON_VERSION=3.7.9
 
 COPY install.sh /install.sh
 RUN /install.sh && rm -rf /install.sh

--- a/base/debian-9/install.sh
+++ b/base/debian-9/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 set -e
-apt-get update
-apt-get install -y locales wget gnupg apt-utils
+
+# Generate UTF-8 char map and locale
+apt-get update -y
+apt-get install -y --no-install-recommends locales wget gnupg apt-utils
 echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
 rm -f /usr/share/locale/locale.alias
 ln -s /etc/locale.alias /usr/share/locale/locale.alias
@@ -27,37 +29,59 @@ export LANG=en_US.utf8
 ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 /usr/sbin/dpkg-reconfigure -f noninteractive tzdata
 
-# Install additional dependencies
-echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" >> /etc/apt/sources.list
-apt-key adv --keyserver https://keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
-apt-get update
+# Install utility packages
+apt-get install -y --no-install-recommends curl sudo libgssapi-krb5-2 busybox procps acl gcc make \
+                                           libffi-dev libssl-dev make build-essential libbz2-dev \
+                                           wget xz-utils ca-certificates zlib1g-dev
 
-# put back tools for customer support
-apt-cache show ansible
-apt-get install -y --no-install-recommends ansible curl sudo libgssapi-krb5-2 busybox procps acl
-apt-get install -y --no-install-recommends python-requests python-jmespath
+# Install Python and necessary packages
+PY_SHORT=${PYTHON_VERSION%.*}
+wget -O /tmp/python.tgz https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+mkdir -p /tmp/pyinstall
+tar -xzC /tmp/pyinstall/ --strip-components=1 -f /tmp/python.tgz
+rm /tmp/python.tgz
+cd /tmp/pyinstall
+./configure --enable-optimizations --prefix=/usr --with-ensurepip=install
+make altinstall LDFLAGS="-Wl,--strip-all"
+rm -rf /tmp/pyinstall
+ln -sf /usr/bin/python${PY_SHORT} /usr/bin/python
+ln -sf /usr/bin/pip${PY_SHORT} /usr/bin/pip
+# For ansible apt module
+cd /tmp
+apt-get download python3-apt=1.4.2
+dpkg -x python3-apt_1.4.2_amd64.deb python3-apt
+rm python3-apt_1.4.2_amd64.deb
+cp -r /tmp/python3-apt/usr/lib/python3/dist-packages/* /usr/lib/python${PY_SHORT}/site-packages/
+cd /usr/lib/python${PY_SHORT}/site-packages/
+cp apt_pkg.cpython-35m-x86_64-linux-gnu.so apt_pkg.so
+cp apt_inst.cpython-35m-x86_64-linux-gnu.so apt_inst.so
+rm -rf /tmp/python3-apt
+# Install splunk-ansible dependencies
+cd /
+pip -q --no-cache-dir install wheel requests ansible jmespath --upgrade
+# Remove tests packaged in python libs
+find /usr/lib/ -depth \( -type d -a -not -wholename '*/ansible/plugins/test' -a \( -name test -o -name tests -o -name idle_test \) \) -exec rm -rf '{}' \;
+find /usr/lib/ -depth \( -type f -a -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) -exec rm -rf '{}' \;
+find /usr/lib/ -depth \( -type f -a -name 'wininst-*.exe' \) -exec rm -rf '{}' \;
+ldconfig
+
+apt-get remove -y --allow-remove-essential gcc libffi-dev libssl-dev make build-essential libbz2-dev xz-utils zlib1g-dev
+apt-get autoremove -y --allow-remove-essential
 
 # Install scloud
 wget -O /usr/bin/scloud.tar.gz ${SCLOUD_URL}
 tar -xf /usr/bin/scloud.tar.gz -C /usr/bin/
 rm /usr/bin/scloud.tar.gz
 
+# Enable busybox symlinks
 cd /bin
-ln -s busybox clear
-ln -s busybox find
-ln -s busybox diff
-ln -s busybox killall
-ln -s busybox netstat
-ln -s busybox nslookup
-ln -s busybox ping
-ln -s busybox ping6
-ln -s busybox readline
-ln -s busybox route
-ln -s busybox syslogd
-ln -s busybox tail
-ln -s busybox traceroute
-ln -s busybox vi
+BBOX_LINKS=( clear find diff hostname killall netstat nslookup ping ping6 readline route syslogd tail traceroute vi )
+for item in "${BBOX_LINKS[@]}"
+do
+  ln -s busybox $item || true
+done
 chmod u+s /bin/ping
 
-apt-get clean autoclean
+# Clean
+apt clean autoclean
 rm -rf /var/lib/apt/lists/*

--- a/base/redhat-8/Dockerfile
+++ b/base/redhat-8/Dockerfile
@@ -16,7 +16,7 @@
 # the container catalog moved from registry.access.redhat.com to registry.redhat.io
 # So at some point before they deprecate the old registry we have to make sure that
 # we have access to the new registry and change where we pull the ubi image from.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-201
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-230
 
 LABEL name="splunk" \
       maintainer="support@splunk.com" \

--- a/base/redhat-8/Dockerfile
+++ b/base/redhat-8/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 # the container catalog moved from registry.access.redhat.com to registry.redhat.io
 # So at some point before they deprecate the old registry we have to make sure that
 # we have access to the new registry and change where we pull the ubi image from.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2-267
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-201
+
 LABEL name="splunk" \
       maintainer="support@splunk.com" \
       vendor="splunk" \
@@ -25,7 +26,8 @@ LABEL name="splunk" \
       description="Splunk Enterprise is a platform for operational intelligence. Our software lets you collect, analyze, and act upon the untapped value of big data that your technology infrastructure, security systems, and business applications generate. It gives you insights to drive operational performance and business results."
 
 ARG SCLOUD_URL
-ENV SCLOUD_URL ${SCLOUD_URL}
+ENV SCLOUD_URL=${SCLOUD_URL} \
+    PYTHON_VERSION=3.7.9
 
 COPY install.sh /install.sh
 

--- a/clair-whitelist.yml
+++ b/clair-whitelist.yml
@@ -12,3 +12,6 @@ generalwhitelist:
   CVE-2010-4052: False Positive.  Being flagged even though glibc is > 2.12
   CVE-2010-4756: There is no ftp daemon running in the container.
   CVE-2010-4051: False Positive.  Installed libc is > 2.12
+  CVE-2020-29361: Fixed in 0.23.15-2+deb10u1 per https://security-tracker.debian.org/tracker/CVE-2020-29361
+  CVE-2020-29362: Fixed in 0.23.15-2+deb10u1 per https://security-tracker.debian.org/tracker/CVE-2020-29362
+  CVE-2020-29363: Fixed in 0.23.15-2+deb10u1 per https://security-tracker.debian.org/tracker/CVE-2020-29363

--- a/py23-image/debian-10/Dockerfile
+++ b/py23-image/debian-10/Dockerfile
@@ -4,5 +4,7 @@ USER root
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends libpython-dev ansible python-requests python-jmespath python-yaml \
+    && ln -sf /usr/bin/python3.7 /usr/bin/python3 \
+    && ln -sf /usr/bin/pip3.7 /usr/bin/pip3 \
     && ln -sf /usr/bin/python2 /usr/bin/python \
     && ln -sf /usr/bin/pip2 /usr/bin/pip

--- a/py23-image/debian-10/Dockerfile
+++ b/py23-image/debian-10/Dockerfile
@@ -2,6 +2,7 @@ ARG SPLUNK_PRODUCT=splunk
 FROM ${SPLUNK_PRODUCT}-debian-10:latest
 USER root
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends python3 python3-pip python3-setuptools python3-requests python3-yaml
-RUN pip3 --no-cache-dir install ansible
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends libpython-dev ansible python-requests python-jmespath python-yaml \
+    && ln -sf /usr/bin/python2 /usr/bin/python \
+    && ln -sf /usr/bin/pip2 /usr/bin/pip

--- a/py23-image/debian-10/Dockerfile
+++ b/py23-image/debian-10/Dockerfile
@@ -3,8 +3,8 @@ FROM ${SPLUNK_PRODUCT}-debian-10:latest
 USER root
 
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends libpython-dev ansible python-requests python-jmespath python-yaml \
+    && apt-get install -y --no-install-recommends libpython-dev ansible python-pip python-requests python-jmespath python-yaml \
     && ln -sf /usr/bin/python3.7 /usr/bin/python3 \
     && ln -sf /usr/bin/pip3.7 /usr/bin/pip3 \
-    && ln -sf /usr/bin/python2 /usr/bin/python \
-    && ln -sf /usr/bin/pip2 /usr/bin/pip
+    && ln -sf /usr/bin/python3.7 /usr/bin/python \
+    && ln -sf /usr/bin/pip3.7 /usr/bin/pip

--- a/py23-image/debian-9/Dockerfile
+++ b/py23-image/debian-9/Dockerfile
@@ -3,8 +3,8 @@ FROM ${SPLUNK_PRODUCT}-debian-9:latest
 USER root
 
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends libpython-dev ansible python-requests python-jmespath python-yaml \
+    && apt-get install -y --no-install-recommends libpython-dev ansible python-pip python-requests python-jmespath python-yaml \
     && ln -sf /usr/bin/python3.7 /usr/bin/python3 \
     && ln -sf /usr/bin/pip3.7 /usr/bin/pip3 \
-    && ln -sf /usr/bin/python2 /usr/bin/python \
-    && ln -sf /usr/bin/pip2 /usr/bin/pip
+    && ln -sf /usr/bin/python3.7 /usr/bin/python \
+    && ln -sf /usr/bin/pip3.7 /usr/bin/pip

--- a/py23-image/debian-9/Dockerfile
+++ b/py23-image/debian-9/Dockerfile
@@ -4,5 +4,7 @@ USER root
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends libpython-dev ansible python-requests python-jmespath python-yaml \
+    && ln -sf /usr/bin/python3.7 /usr/bin/python3 \
+    && ln -sf /usr/bin/pip3.7 /usr/bin/pip3 \
     && ln -sf /usr/bin/python2 /usr/bin/python \
     && ln -sf /usr/bin/pip2 /usr/bin/pip

--- a/py23-image/debian-9/Dockerfile
+++ b/py23-image/debian-9/Dockerfile
@@ -2,26 +2,7 @@ ARG SPLUNK_PRODUCT=splunk
 FROM ${SPLUNK_PRODUCT}-debian-9:latest
 USER root
 
-RUN apt-get update
-RUN apt-get install -y gcc make \
-    build-essential checkinstall libreadline-gplv2-dev libncursesw5-dev libssl-dev \
-    libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev
-# INFRA-15385: manual installation of python 3.7 as default distro version is 3.5
-RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
-    && tar xzf Python-3.7.4.tgz \
-    && cd Python-3.7.4 \
-    && ./configure --enable-optimizations --prefix=/usr \
-    && make install \
-    && cd .. \
-    && rm Python-3.7.4.tgz \
-    && rm -r Python-3.7.4 \
-    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3.7 get-pip.py \
-    && rm -f get-pip.py \
-    && ln -s /usr/share/pyshared/lsb_release.py /usr/lib/python3.7/site-packages/lsb_release.py
-#removing all intermediate dependencies. All the stuff below comes up to 200+MB
-RUN apt-get remove --purge -y gcc make build-essential checkinstall libreadline-gplv2-dev libncursesw5-dev \
-    libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev \
-    && apt autoremove -y \
-    && apt autoclean
-RUN pip3 --no-cache-dir install ansible requests
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends libpython-dev ansible python-requests python-jmespath python-yaml \
+    && ln -sf /usr/bin/python2 /usr/bin/python \
+    && ln -sf /usr/bin/pip2 /usr/bin/pip

--- a/py23-image/redhat-8/Dockerfile
+++ b/py23-image/redhat-8/Dockerfile
@@ -2,25 +2,8 @@ ARG SPLUNK_PRODUCT=splunk
 FROM ${SPLUNK_PRODUCT}-redhat-8:latest
 USER root
 
-RUN microdnf -y update \
-    && microdnf -y install make gcc openssl-devel bzip2-devel libffi-devel
-# INFRA-15385: manual installation of python 3.7 as default distro version is 3.6
-RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz \
-    && tar xzf Python-3.7.4.tgz \
-    && cd Python-3.7.4 \
-    && ./configure --enable-optimizations --prefix=/usr \
-    && make install \
-    && cd .. \
-    && rm Python-3.7.4.tgz \
-    && rm -r Python-3.7.4 \
-    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3.7 get-pip.py \
-    && rm -f get-pip.py \
-    #pip version is not automatically "fixed", unlike debian-based
+RUN microdnf -y -nodocs update \
+    && microdnf -y -nodocs install install python2-pip python2-devel \
+    && pip2 --no-cache-dir install requests ansible jmespath \
     && ln -sf /usr/bin/python2 /usr/bin/python \
-    && ln -sf /usr/bin/pip2 /usr/bin/pip \
-    && ln -sf /usr/bin/pip3.7 /usr/bin/pip3
-#microdnf persists metadata which is a problem for removing packages. So have to clean first before removing. 
-RUN microdnf clean all \
-	&& microdnf remove -y gcc make openssl-devel bzip2-devel libffi-devel
-RUN pip3 -q --no-cache-dir install requests ansible
+    && ln -sf /usr/bin/pip2 /usr/bin/pip

--- a/py23-image/redhat-8/Dockerfile
+++ b/py23-image/redhat-8/Dockerfile
@@ -7,5 +7,5 @@ RUN microdnf -y --nodocs update \
     && pip2 --no-cache-dir install requests ansible jmespath \
     && ln -sf /usr/bin/python3.7 /usr/bin/python3 \
     && ln -sf /usr/bin/pip3.7 /usr/bin/pip3 \
-    && ln -sf /usr/bin/python2 /usr/bin/python \
-    && ln -sf /usr/bin/pip2 /usr/bin/pip
+    && ln -sf /usr/bin/python3.7 /usr/bin/python \
+    && ln -sf /usr/bin/pip3.7 /usr/bin/pip

--- a/py23-image/redhat-8/Dockerfile
+++ b/py23-image/redhat-8/Dockerfile
@@ -2,8 +2,10 @@ ARG SPLUNK_PRODUCT=splunk
 FROM ${SPLUNK_PRODUCT}-redhat-8:latest
 USER root
 
-RUN microdnf -y -nodocs update \
-    && microdnf -y -nodocs install install python2-pip python2-devel \
+RUN microdnf -y --nodocs update \
+    && microdnf -y --nodocs install python2-pip python2-devel \
     && pip2 --no-cache-dir install requests ansible jmespath \
+    && ln -sf /usr/bin/python3.7 /usr/bin/python3 \
+    && ln -sf /usr/bin/pip3.7 /usr/bin/pip3 \
     && ln -sf /usr/bin/python2 /usr/bin/python \
     && ln -sf /usr/bin/pip2 /usr/bin/pip

--- a/splunk/common-files/Dockerfile
+++ b/splunk/common-files/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk/common-files/createdefaults.py
+++ b/splunk/common-files/createdefaults.py
@@ -1,5 +1,5 @@
 #! /usr/bin/python
-# Copyright 2018-2020 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk/common-files/entrypoint.sh
+++ b/splunk/common-files/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-# Copyright 2018 Splunk
+# Copyright 2018-2021 Splunk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
https://github.com/splunk/docker-splunk/issues/428

Updating redhat and debian base images to only use python3. Changelist:
* Updates to comments/copyrights throughout
* General clean-up + comments on the various `install.sh` scripts
* Finer control of python3 versioning by installing from source on debian-9, debian-10, and redhat-8
* I found that by installing from source, I was able to shave 100-200MB from the image; this is in part due to stripping symbols from compiled binaries and removing a _lot_ of tests that came packaged with python libraries
* New image sizes for reference:
```
base-redhat-8-orig                            latest         3d6c7b666b71   21 hours ago        576MB
base-debian-10-orig                           latest         98ae41e4be98   21 hours ago        445MB
...
base-redhat-8                                 latest         6f3494b4e300   6 hours ago         352MB
base-debian-10                                latest         d4cf321fc5d3   About an hour ago   312MB
```