### PR TITLE
Feature/trivy scanner

### DIFF
--- a/.circleci/anchore-policy.json
+++ b/.circleci/anchore-policy.json
@@ -1,0 +1,20 @@
+{
+  "name": "IgnoreUnfixablePkgs",
+  "version": "1_0",
+  "comment": "Policy for basic checks",
+  "id": "ba6daa06-da3b-46d3-9e22-f01f07b0489a",
+  "rules": [
+    {
+      "action": "STOP",
+      "gate": "vulnerabilities",
+      "id": "80569900-d6b3-4391-b2a0-bf34cf6d813d",
+      "params": [
+        { "name": "package_type", "value": "all" },
+        { "name": "severity_comparison", "value": ">" },
+        { "name": "severity", "value": "medium" },
+        { "name": "fix_available", "value": "true"}
+      ],
+      "trigger": "package"
+    }
+  ]
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
             for image in ./workspace_cache/*.tar; do
               echo "$image"
               [ -e "$image" ] || continue
-              ./trivy --severity HIGH,CRITICAL --exit-code 1 --no-progress -f "$image"
+              ./trivy image --severity HIGH,CRITICAL --exit-code 0 --no-progress -f "$image"
             done
 
   test_redhat_8_small:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ jobs:
       - anchore/analyze_local_image:
           image_name: 'splunk-redhat-8 uf-redhat-8 base-redhat-8 splunk-debian-10 uf-debian-10 base-debian-10'
           policy_failure: true
+          policy_bundle_file_path: .circleci/anchore-policy.json
           timeout: '600'
       - anchore/parse_reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
             for image in ./workspace_cache/*.tar; do
               echo "$image"
               [ -e "$image" ] || continue
-              ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 0 --no-progress -i "$image"
+              ./trivy image --exit-code 0 --no-progress -i "$image"
             done
 
   test_redhat_8_small:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,6 @@ jobs:
             done
       - anchore/analyze_local_image:
           image_name: 'splunk-redhat-8 uf-redhat-8 base-redhat-8 splunk-debian-10 uf-debian-10 base-debian-10'
-          policy_failure: true
           policy_bundle_file_path: .circleci/anchore-policy.json
           timeout: '600'
       - anchore/parse_reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ jobs:
               [ -e "$image" ] || continue
               ./grype "$image"
             done
+          no_output_timeout: 1h
 
   scan_images_anchore:
     executor: anchore/anchore_engine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - anchore/analyze_local_image:
           image_name: 'splunk-redhat-8 uf-redhat-8 base-redhat-8 splunk-debian-10 uf-debian-10 base-debian-10'
           policy_failure: true
-          timeout: '300'
+          timeout: '600'
       - anchore/parse_reports
       - store_artifacts:
           path: anchore-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ executors:
       image: ubuntu-1604:201903-01
     resource_class: xlarge
 
+orbs:
+  anchore-engine: anchore/anchore-engine@1.8.2
+
 jobs:
 
   build_debian_10:
@@ -30,7 +33,7 @@ jobs:
           command: |
             docker save -o workspace_cache/splunk-debian-10.tar splunk-debian-10:latest
             docker save -o workspace_cache/uf-debian-10.tar uf-debian-10:latest
-            docker save -o workspace_cache/uf-debian-10.tar base-debian-10:latest
+            docker save -o workspace_cache/base-debian-10.tar base-debian-10:latest
       - persist_to_workspace:
           root: workspace_cache
           paths:
@@ -52,14 +55,14 @@ jobs:
           command: |
             docker save -o workspace_cache/splunk-redhat-8.tar splunk-redhat-8:latest
             docker save -o workspace_cache/uf-redhat-8.tar uf-redhat-8:latest
-            docker save -o workspace_cache/uf-debian-10.tar base-redhat-8:latest
+            docker save -o workspace_cache/base-debian-10.tar base-redhat-8:latest
       - persist_to_workspace:
           root: workspace_cache
           paths:
             - splunk-redhat-8.tar
             - uf-redhat-8.tar
 
-  scan_images:
+  scan_images_trivy:
     executor: py3
     steps:
       - checkout
@@ -81,8 +84,30 @@ jobs:
           command: |
             for image in ./workspace_cache/*.tar; do
               [ -e "$image" ] || continue
-              ./trivy image --exit-code 0 --severity "HIGH,CRITICAL" --no-progress -i "$image"
+              ./trivy image --exit-code 0 --ignore-unfixed --severity "HIGH,CRITICAL" --no-progress -i "$image"
             done
+
+  scan_images_anchore:
+    executor: anchore/anchore_engine
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: workspace_cache
+      - run:
+          name: Load images
+          command: |
+            for image in ./workspace_cache/*.tar; do
+              [ -e "$image" ] || continue
+              docker load --input "$image"
+            done
+      - anchore/analyze_local_image:
+          image_name: 'splunk-redhat-8 uf-redhat-8 base-redhat-8 splunk-debian-10 uf-debian-10 base-debian-10'
+          policy_failure: true
+          timeout: '300'
+      - anchore/parse_reports
+      - store_artifacts:
+          path: anchore-reports
 
   test_redhat_8_small:
     executor: circleci_medium
@@ -221,7 +246,11 @@ workflows:
     jobs:
       - build_debian_10
       - build_redhat_8
-      - scan_images:
+      - scan_images_trivy:
+          requires:
+            - build_debian_10
+            - build_redhat_8
+      - scan_images_anchore:
           requires:
             - build_debian_10
             - build_redhat_8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,13 +99,16 @@ jobs:
       - run:
           name: Install grype
           command: |
-            curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b ./
+            curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b .
+            chmod +x ./grype
+            ls
       - run:
           name: Scan images
           command: |
             for image in ./workspace_cache/*.tar; do
+              echo "Scanning $image"
               [ -e "$image" ] || continue
-              ./grype "$image"
+              ./grype "$image" --scope all-layers
             done
           no_output_timeout: 1h
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs:
       - run:
           name: Install trivy
           command: |
-            apk add --update-cache --upgrade curl
             VERSION=$(
                 curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | \
                 grep '"tag_name":' | \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,14 +72,16 @@ jobs:
                 grep '"tag_name":' | \
                 sed -E 's/.*"v([^"]+)".*/\1/'
             )
-
             wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz
             tar zxvf trivy_${VERSION}_Linux-64bit.tar.gz
       - run:
           name: Scan images
           command: |
+            ls
+            ls /root/project/workspace_cache/
             for image in /root/project/workspace_cache/*.tar; do
-              ./trivy --severity HIGH,CRITICAL --exit-code 1 --no-progress "$image"
+              [ -e "$filename" ] || continue
+              ./trivy --severity HIGH,CRITICAL --exit-code 1 --no-progress -f "$image"
             done
 
   test_redhat_8_small:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,9 @@ jobs:
           name: Scan images
           command: |
             ls
-            ls /root/project/workspace_cache/
-            for image in /root/project/workspace_cache/*.tar; do
-              [ -e "$filename" ] || continue
+            for image in ./workspace_cache/*.tar; do
+              echo "$image"
+              [ -e "$image" ] || continue
               ./trivy --severity HIGH,CRITICAL --exit-code 1 --no-progress -f "$image"
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,6 @@ executors:
       image: ubuntu-1604:201903-01
     resource_class: xlarge
 
-orbs:
-  clair: ovotech/clair-scanner@1.6.0
-
 jobs:
 
   build_debian_10:
@@ -61,15 +58,31 @@ jobs:
             - uf-redhat-8.tar
 
   scan_images:
-    executor: clair/default
+    executor: py3
     steps:
       - checkout
       - setup_remote_docker
       - attach_workspace:
           at: workspace_cache
-      - modified-clair-scan:
-          docker_tar_dir: /root/project/workspace_cache/
-          whitelist: /root/project/clair-whitelist.yml
+      - run:
+          name: Install trivy
+          command: |
+            apk add --update-cache --upgrade curl
+            VERSION=$(
+                curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | \
+                grep '"tag_name":' | \
+                sed -E 's/.*"v([^"]+)".*/\1/'
+            )
+
+            wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz
+            tar zxvf trivy_${VERSION}_Linux-64bit.tar.gz
+            mv trivy /usr/local/bin
+      - run:
+          name: Scan images
+          command: |
+            for image in /root/project/workspace_cache/*.tar; do
+              trivy --severity HIGH,CRITICAL --exit-code 1 --no-progress "$image"
+            done
 
   test_redhat_8_small:
     executor: circleci_medium
@@ -228,138 +241,3 @@ workflows:
           requires:
             - build_debian_10
             - build_redhat_8
-
-commands:
-  modified-clair-scan:
-    description: "Scan an image for vulnerabilities"
-    parameters:
-      image:
-        type: "string"
-        description: "Name of the image to scan"
-        default: ""
-      image_file:
-        type: "string"
-        description: "Path to a file of images to scan"
-        default: ""
-      whitelist:
-        type: "string"
-        description: "Path to a CVE whitelist"
-        default: ""
-      severity_threshold:
-        type: "string"
-        description: "The threshold (equal and above) at which discovered vulnerabilities are reported. May be 'Defcon1', 'Critical', 'High', 'Medium', 'Low', 'Negligible' or 'Unknown'"
-        default: "High"
-      fail_on_discovered_vulnerabilities:
-        type: "boolean"
-        description: "Fail command when vulnerabilities at severity equal to or above the threshold are discovered"
-        default: true
-      fail_on_unsupported_images:
-        type: "boolean"
-        description: "Fail command when image cannot be scanned for vulnerabilities"
-        default: true
-      disable_verbose_console_output:
-        type: "boolean"
-        description: "Disable verbose console output"
-        default: false
-      docker_tar_dir:
-        type: "string"
-        description: "Path of directory that Docker tarballs are stored"
-        default: "/docker-tars"
-    steps:
-      - run:
-          name: "Vulnerability scan"
-          command: |
-            #!/usr/bin/env bash
-
-            set -xe
-
-            DOCKER_TAR_DIR="<< parameters.docker_tar_dir >>"
-
-            if [ -z "<< parameters.image_file >><< parameters.image >>" ] && [ -z "$(ls -A "$DOCKER_TAR_DIR" 2>/dev/null)" ]; then
-                echo "image_file or image parameters or docker tarballs must be present"
-                exit 255
-            fi
-
-            REPORT_DIR=/clair-reports
-            mkdir $REPORT_DIR
-
-            DB=$(docker run -p 5432:5432 -d arminc/clair-db:latest)
-            CLAIR=$(docker run -p 6060:6060 --link "$DB":postgres -d arminc/clair-local-scan:latest)
-            CLAIR_SCANNER=$(docker run -v /var/run/docker.sock:/var/run/docker.sock -d ovotech/clair-scanner@sha256:8a4f920b4e7e40dbcec4a6168263d45d3385f2970ee33e5135dd0e3b75d39c75 tail -f /dev/null)
-
-            clair_ip=$(docker exec -it "$CLAIR" hostname -i | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+')
-            scanner_ip=$(docker exec -it "$CLAIR_SCANNER" hostname -i | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+')
-
-            if [ -n "<< parameters.whitelist >>" ]; then
-                cat "<< parameters.whitelist >>"
-                docker cp "<< parameters.whitelist >>" "$CLAIR_SCANNER:/whitelist.yml"
-
-                WHITELIST="-w /whitelist.yml"
-            fi
-
-            function scan() {
-                local image=$1
-                # replace forward-slashes and colons with underscores
-                munged_image=$(echo "$image" | sed 's/\//_/g' | sed 's/:/_/g')
-                sanitised_image_filename="${munged_image}.json"
-                local ret=0
-                local docker_cmd=(docker exec -it "$CLAIR_SCANNER" clair-scanner \
-                    --ip "$scanner_ip" \
-                    --clair=http://"$clair_ip":6060 \
-                    -t "<< parameters.severity_threshold >>" \
-                    --report "/$sanitised_image_filename" \
-                    --log "/log.json" $WHITELIST \
-                    --reportAll=true \
-                    --exit-when-no-features=false \
-                    "$image")
-
-                # if verbose output is disabled, analyse status code for more fine-grained output
-                if [ "<< parameters.disable_verbose_console_output >>" == "true" ];then
-                    "${docker_cmd[@]}" > /dev/null 2>&1 || ret=$?
-                else
-                    "${docker_cmd[@]}" 2>&1 || ret=$?
-                fi
-                if [ $ret -eq 0 ]; then
-                    echo "No unapproved vulnerabilities"
-                elif [ $ret -eq 1 ]; then
-                    echo "Unapproved vulnerabilities found"
-                    if [ "<< parameters.fail_on_discovered_vulnerabilities >>" == "true" ];then
-                        EXIT_STATUS=1
-                    fi
-                elif [ $ret -eq 5 ]; then
-                    echo "Image was not scanned, not supported."
-                    if [ "<< parameters.fail_on_unsupported_images >>" == "true" ];then
-                        EXIT_STATUS=1
-                    fi
-                else
-                    echo "Unknown clair-scanner return code $ret."
-                    EXIT_STATUS=1
-                fi
-
-                docker cp "$CLAIR_SCANNER:/$sanitised_image_filename" "$REPORT_DIR/$sanitised_image_filename" || true
-            }
-
-            EXIT_STATUS=0
-
-            for entry in "$DOCKER_TAR_DIR"/*.tar; do
-                [ -e "$entry" ] || continue
-                images=$(docker load -i "$entry" | sed -e 's/Loaded image: //g')
-                for image in $images; do
-                    scan "$image"
-                done
-            done
-
-            if [ -n "<< parameters.image_file >>" ]; then
-                images=$(cat "<< parameters.image_file >>")
-                for image in $images; do
-                    scan "$image"
-                done
-            fi
-            if [ -n "<< parameters.image >>" ]; then
-                image="<< parameters.image >>"
-                scan "$image"
-            fi
-
-            exit $EXIT_STATUS
-      - store_artifacts:
-          path: /clair-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
     resource_class: xlarge
 
 orbs:
-  anchore-engine: anchore/anchore-engine@1.8.2
+  anchore: anchore/anchore-engine@1.8.2
 
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,13 +103,16 @@ jobs:
             chmod +x ./grype
             ls
       - run:
-          name: Scan images
+          name: Load images
           command: |
             for image in ./workspace_cache/*.tar; do
-              echo "Scanning $image"
               [ -e "$image" ] || continue
-              ./grype "$image" --scope all-layers
+              docker load --input "$image"
             done
+      - run:
+          name: Scan images
+          command: |
+            ./grype base-redhat-8:latest --scope all-layers
           no_output_timeout: 1h
 
   scan_images_anchore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
             for image in ./workspace_cache/*.tar; do
               echo "$image"
               [ -e "$image" ] || continue
-              ./trivy image --severity HIGH,CRITICAL --exit-code 0 --no-progress -f "$image"
+              ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 0 --no-progress -i "$image"
             done
 
   test_redhat_8_small:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
           paths:
             - splunk-debian-10.tar
             - uf-debian-10.tar
+            - base-debian-10.tar
 
   build_redhat_8:
     executor: py3
@@ -55,12 +56,13 @@ jobs:
           command: |
             docker save -o workspace_cache/splunk-redhat-8.tar splunk-redhat-8:latest
             docker save -o workspace_cache/uf-redhat-8.tar uf-redhat-8:latest
-            docker save -o workspace_cache/base-debian-10.tar base-redhat-8:latest
+            docker save -o workspace_cache/base-redhat-8.tar base-redhat-8:latest
       - persist_to_workspace:
           root: workspace_cache
           paths:
             - splunk-redhat-8.tar
             - uf-redhat-8.tar
+            - base-redhat-8.tar
 
   scan_images_trivy:
     executor: py3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,11 @@ jobs:
 
             wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz
             tar zxvf trivy_${VERSION}_Linux-64bit.tar.gz
-            mv trivy /usr/local/bin
       - run:
           name: Scan images
           command: |
             for image in /root/project/workspace_cache/*.tar; do
-              trivy --severity HIGH,CRITICAL --exit-code 1 --no-progress "$image"
+              ./trivy --severity HIGH,CRITICAL --exit-code 1 --no-progress "$image"
             done
 
   test_redhat_8_small:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,25 @@ jobs:
               ./trivy image --exit-code 0 --ignore-unfixed --severity "HIGH,CRITICAL" --no-progress -i "$image"
             done
 
+  scan_images_grype:
+    executor: py3
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: workspace_cache
+      - run:
+          name: Install grype
+          command: |
+            curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b ./
+      - run:
+          name: Scan images
+          command: |
+            for image in ./workspace_cache/*.tar; do
+              [ -e "$image" ] || continue
+              ./grype "$image"
+            done
+
   scan_images_anchore:
     executor: anchore/anchore_engine
     steps:
@@ -248,6 +267,10 @@ workflows:
     jobs:
       - build_debian_10
       - build_redhat_8
+      - scan_images_grype:
+          requires:
+            - build_debian_10
+            - build_redhat_8
       - scan_images_trivy:
           requires:
             - build_debian_10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,32 +89,6 @@ jobs:
               ./trivy image --exit-code 0 --ignore-unfixed --severity "HIGH,CRITICAL" --no-progress -i "$image"
             done
 
-  scan_images_grype:
-    executor: py3
-    steps:
-      - checkout
-      - setup_remote_docker
-      - attach_workspace:
-          at: workspace_cache
-      - run:
-          name: Install grype
-          command: |
-            curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b .
-            chmod +x ./grype
-            ls
-      - run:
-          name: Load images
-          command: |
-            for image in ./workspace_cache/*.tar; do
-              [ -e "$image" ] || continue
-              docker load --input "$image"
-            done
-      - run:
-          name: Scan images
-          command: |
-            ./grype base-redhat-8:latest --scope all-layers
-          no_output_timeout: 1h
-
   scan_images_anchore:
     executor: anchore/anchore_engine
     steps:
@@ -274,10 +248,6 @@ workflows:
     jobs:
       - build_debian_10
       - build_redhat_8
-      - scan_images_grype:
-          requires:
-            - build_debian_10
-            - build_redhat_8
       - scan_images_trivy:
           requires:
             - build_debian_10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
           command: |
             docker save -o workspace_cache/splunk-debian-10.tar splunk-debian-10:latest
             docker save -o workspace_cache/uf-debian-10.tar uf-debian-10:latest
+            docker save -o workspace_cache/uf-debian-10.tar base-debian-10:latest
       - persist_to_workspace:
           root: workspace_cache
           paths:
@@ -51,6 +52,7 @@ jobs:
           command: |
             docker save -o workspace_cache/splunk-redhat-8.tar splunk-redhat-8:latest
             docker save -o workspace_cache/uf-redhat-8.tar uf-redhat-8:latest
+            docker save -o workspace_cache/uf-debian-10.tar base-redhat-8:latest
       - persist_to_workspace:
           root: workspace_cache
           paths:
@@ -77,11 +79,9 @@ jobs:
       - run:
           name: Scan images
           command: |
-            ls
             for image in ./workspace_cache/*.tar; do
-              echo "$image"
               [ -e "$image" ] || continue
-              ./trivy image --exit-code 0 --no-progress -i "$image"
+              ./trivy image --exit-code 0 --severity "HIGH,CRITICAL" --no-progress -i "$image"
             done
 
   test_redhat_8_small:


### PR DESCRIPTION
Recent scans of Clair have been clean, although we seem to be catching container image CVEs from other sources indicating some problems with a few OS platform libraries. Given this, I think it may be best to drop Clair and explore other container image scanners. 

This PR sets up both trivy as well as anchore to vet alternative image scanning services. I'm opening this PR for review, but I'll be syncing with the ProdSec tooling team after the holidays to see what their opinions are of both of these two solutions (or potentially other recommendations from them). 