### PR TITLE
fix: add btool check for HTTPS on health check

### DIFF
--- a/splunk/common-files/checkstate.sh
+++ b/splunk/common-files/checkstate.sh
@@ -23,7 +23,7 @@
 # health results
 
 if [[ "" == "$NO_HEALTHCHECK" ]]; then
-    if [[ "false" == "$SPLUNKD_SSL_ENABLE" ]]; then
+    if [[ "false" == "$SPLUNKD_SSL_ENABLE" || "false" == "$(/opt/splunk/bin/splunk btool server list | grep enableSplunkdSSL | cut -d\  -f 3)" ]]; then
       SCHEME="http"
 	else
       SCHEME="https"


### PR DESCRIPTION
Not all methods of disabling HTTPS on the API will set the SPLUNKD_SSL_ENABLE flag, which would then cause this health check to fail, and the container to continually restart without an apparent cause.  

This change checks the effective `enableSplunkdSSL` value in server.conf, which is set to "false" when the Ansible defaults.yml has splunk.ssl.enable set to 0.