### PR TITLE
Updating teardown for graceful shutdown procedure

### DIFF
--- a/splunk/common-files/entrypoint.sh
+++ b/splunk/common-files/entrypoint.sh
@@ -27,7 +27,10 @@ setup() {
 
 teardown() {
 	# Always run the stop command on termination
-	${SPLUNK_HOME}/bin/splunk stop 2>/dev/null || true
+	if [ `whoami` != "${SPLUNK_USER}" ]; then
+		RUN_AS_SPLUNK="sudo -u ${SPLUNK_USER}"
+	fi
+	${RUN_AS_SPLUNK} ${SPLUNK_HOME}/bin/splunk stop || true
 }
 
 trap teardown SIGINT SIGTERM
@@ -83,7 +86,6 @@ start_and_exit() {
 }
 
 start() {
-	trap teardown EXIT
 	start_and_exit
 	watch_for_failure
 }
@@ -94,7 +96,6 @@ configure_multisite() {
 }
 
 restart(){
-	trap teardown EXIT
 	sh -c "echo 'restarting' > ${CONTAINER_ARTIFACT_DIR}/splunk-container.state"
 	prep_ansible
 	${SPLUNK_HOME}/bin/splunk stop 2>/dev/null || true

--- a/tests/executor.py
+++ b/tests/executor.py
@@ -147,7 +147,7 @@ class Executor(object):
             for container in containers:
                 # The healthcheck on our Splunk image is not reliable - resorting to checking logs
                 if container.get("Labels", {}).get("maintainer") == "support@splunk.com":
-                    output = self.client.logs(container["Id"], tail=10)
+                    output = self.client.logs(container["Id"], tail=5)
                     if "unable to" in output or "denied" in output or "splunkd.pid file is unreadable" in output:
                         self.logger.error("Container {} did not start properly, last log line: {}".format(container["Names"][0], output))
                     elif "Ansible playbook complete" in output:

--- a/tests/test_single_splunk_image.py
+++ b/tests/test_single_splunk_image.py
@@ -852,7 +852,6 @@ class TestDockerSplunk(Executor):
         finally:
             if cid:
                 self.client.remove_container(cid, v=True, force=True)
-     
 
     def test_adhoc_1so_declarative_password(self):
         """
@@ -1014,6 +1013,9 @@ EOL'
             self.client.exec_start(exec_command)
             # Restart the container - it should pick up the new HEC settings in /tmp/defaults/default.yml
             self.client.restart(splunk_container_name)
+            # After restart, a container's logs are preserved. So, sleep in order for the self.wait_for_containers()
+            # to avoid seeing the prior entrypoint's "Ansible playbook complete" string 
+            time.sleep(15)
             assert self.wait_for_containers(1, name=splunk_container_name)
             assert self.check_splunkd("admin", self.password, name=splunk_container_name)
             # Check the new HEC settings
@@ -1047,6 +1049,9 @@ EOL'
             self.client.exec_start(exec_command)
             # Restart the container - it should pick up the new HEC settings in /tmp/defaults/default.yml
             self.client.restart(splunk_container_name)
+            # After restart, a container's logs are preserved. So, sleep in order for the self.wait_for_containers()
+            # to avoid seeing the prior entrypoint's "Ansible playbook complete" string 
+            time.sleep(15)
             assert self.wait_for_containers(1, name=splunk_container_name)
             assert self.check_splunkd("admin", self.password, name=splunk_container_name)
             # Check the new HEC settings
@@ -1078,6 +1083,9 @@ EOL'
             self.client.exec_start(exec_command)
             # Restart the container - it should pick up the new HEC settings in /tmp/defaults/default.yml
             self.client.restart(splunk_container_name)
+            # After restart, a container's logs are preserved. So, sleep in order for the self.wait_for_containers()
+            # to avoid seeing the prior entrypoint's "Ansible playbook complete" string 
+            time.sleep(15)
             assert self.wait_for_containers(1, name=splunk_container_name)
             assert self.check_splunkd("admin", self.password, name=splunk_container_name)
             # Check the new HEC settings
@@ -1102,6 +1110,9 @@ EOL'
             self.client.exec_start(exec_command)
             # Restart the container - it should pick up the new HEC settings in /tmp/defaults/default.yml
             self.client.restart(splunk_container_name)
+            # After restart, a container's logs are preserved. So, sleep in order for the self.wait_for_containers()
+            # to avoid seeing the prior entrypoint's "Ansible playbook complete" string 
+            time.sleep(15)
             assert self.wait_for_containers(1, name=splunk_container_name)
             assert self.check_splunkd("admin", self.password, name=splunk_container_name)
             # Check the new HEC settings
@@ -1288,13 +1299,15 @@ disabled = 1''' in std_out
         assert "java version \"1.8.0" in std_out
         # Restart the container and make sure java is still installed
         self.client.restart("{}_so1_1".format(self.project_name))
+        # After restart, a container's logs are preserved. So, sleep in order for the self.wait_for_containers()
+        # to avoid seeing the prior entrypoint's "Ansible playbook complete" string 
+        time.sleep(15)
         assert self.wait_for_containers(container_count, label="com.docker.compose.project={}".format(self.project_name))
         assert self.check_splunkd("admin", self.password)
         exec_command = self.client.exec_create("{}_so1_1".format(self.project_name), "java -version")
         std_out = self.client.exec_start(exec_command)
         assert "java version \"1.8.0" in std_out
  
-
     def test_compose_1so_java_openjdk8(self):
         # Standup deployment
         self.compose_file_name = "1so_java_openjdk8.yaml"
@@ -1322,6 +1335,9 @@ disabled = 1''' in std_out
         assert "openjdk version \"1.8.0" in std_out
         # Restart the container and make sure java is still installed
         self.client.restart("{}_so1_1".format(self.project_name))
+        # After restart, a container's logs are preserved. So, sleep in order for the self.wait_for_containers()
+        # to avoid seeing the prior entrypoint's "Ansible playbook complete" string 
+        time.sleep(15)
         assert self.wait_for_containers(container_count, label="com.docker.compose.project={}".format(self.project_name))
         assert self.check_splunkd("admin", self.password)
         exec_command = self.client.exec_create("{}_so1_1".format(self.project_name), "java -version")
@@ -1356,6 +1372,9 @@ disabled = 1''' in std_out
         assert "openjdk version \"11.0.2" in std_out
         # Restart the container and make sure java is still installed
         self.client.restart("{}_so1_1".format(self.project_name))
+        # After restart, a container's logs are preserved. So, sleep in order for the self.wait_for_containers()
+        # to avoid seeing the prior entrypoint's "Ansible playbook complete" string 
+        time.sleep(15)
         assert self.wait_for_containers(container_count, label="com.docker.compose.project={}".format(self.project_name))
         assert self.check_splunkd("admin", self.password)
         exec_command = self.client.exec_create("{}_so1_1".format(self.project_name), "java -version")

--- a/uf/common-files/entrypoint.sh
+++ b/uf/common-files/entrypoint.sh
@@ -28,7 +28,10 @@ setup() {
 
 teardown() {
 	# Always run the stop command on termination
-	${SPLUNK_HOME}/bin/splunk stop 2>/dev/null || true
+	if [ `whoami` != "${SPLUNK_USER}" ]; then
+		RUN_AS_SPLUNK="sudo -u ${SPLUNK_USER}"
+	fi
+	${RUN_AS_SPLUNK} ${SPLUNK_HOME}/bin/splunk stop || true
 }
 
 trap teardown SIGINT SIGTERM
@@ -83,13 +86,11 @@ start_and_exit() {
 }
 
 start() {
-	trap teardown EXIT
 	start_and_exit
 	watch_for_failure
 }
 
 restart(){
-	trap teardown EXIT
 	sh -c "echo 'restarting' > ${CONTAINER_ARTIFACT_DIR}/splunk-container.state"
 	prep_ansible
 	${SPLUNK_HOME}/bin/splunk stop 2>/dev/null || true


### PR DESCRIPTION
Addressing https://github.com/splunk/docker-splunk/issues/478

Formerly, any kill/stops would cause this to show up in the logs of the container being removed:
```
splunkd.pid file is unreadable.
```
The teardown routine hasn't been updated to reflect the user permission model changes done a while back. Now with these changes, we should see:
```
$ docker run -d -P --name so1 -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_PASSWORD=helloworld splunk-redhat-8
$ docker kill --signal=SIGTERM so1
$ docker logs so1
...
Ansible playbook complete, will begin streaming splunkd_stderr.log
Stopping splunkd...
Shutting down.  Please wait, as this may take a few minutes.
2021-06-02 22:34:55.309 +0000 Interrupt signal received sent by PID 1548, command="/opt/splunk/bin/splunk stop" (UID 41812, same as my group)
...
Stopping splunk helpers...

Done.
```