### PR TITLE
Set 8.2.1 as Makefile default while DNS fix is pending

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ SPLUNK_ANSIBLE_BRANCH ?= develop
 SPLUNK_COMPOSE ?= cluster_absolute_unit.yaml
 # Set Splunk version/build parameters here to define downstream URLs and file names
 SPLUNK_PRODUCT := splunk
-SPLUNK_VERSION := 8.2.2
-SPLUNK_BUILD := 87344edfcdb4
+SPLUNK_VERSION := 8.2.1
+SPLUNK_BUILD := ddff1c41e5cf
 ifeq ($(shell arch), s390x)
 	SPLUNK_ARCH = s390x
 else


### PR DESCRIPTION
This will make the pipelines green again -- any build URL/path can still be supplied as a variable