### PR TITLE
Fix Makefile typo for bare-centos-8 target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ bare-centos-7: base-centos-7
 		--build-arg SPLUNK_BUILD_URL=${SPLUNK_LINUX_BUILD_URL} \
 		--target bare -t bare-centos-7:${IMAGE_VERSION} .
 
-bare-centos-8: base-centos-7
+bare-centos-8: base-centos-8
 	docker build ${DOCKER_BUILD_FLAGS} \
 		-f splunk/common-files/Dockerfile \
 		--build-arg SPLUNK_BASE_IMAGE=base-centos-8 \


### PR DESCRIPTION
Steps to reproduce: Build the bare-centos-8 target in the Makefile make bare-centos-8

Expected Result: new bare docker splunk image from centos 8

Actual Result: new bare docker splunk image from centos 7

Minor problem, but I am making some changes in this file in my forked repo and came across it and want to fix it upstream.