### PR TITLE
Updating changelog and makefile for Release/8232

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ SPLUNK_COMPOSE ?= cluster_absolute_unit.yaml
 SPLUNK_PRODUCT := splunk
 SPLUNK_VERSION := 8.2.3.2
 SPLUNK_BUILD := 5281ae34c90c
+# Temporarily setting different versions for SE and UF for security patch
+SPLUNK_UF_VERSION := 8.2.3
+SPLUNK_UF_BUILD := cd0848707637
 ifeq ($(shell arch), s390x)
 	SPLUNK_ARCH = s390x
 else
@@ -18,13 +21,13 @@ endif
 # Linux Splunk arguments
 SPLUNK_LINUX_FILENAME ?= splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-Linux-${SPLUNK_ARCH}.tgz
 SPLUNK_LINUX_BUILD_URL ?= https://download.splunk.com/products/${SPLUNK_PRODUCT}/releases/${SPLUNK_VERSION}/linux/${SPLUNK_LINUX_FILENAME}
-UF_LINUX_FILENAME ?= splunkforwarder-${SPLUNK_VERSION}-${SPLUNK_BUILD}-Linux-${SPLUNK_ARCH}.tgz
-UF_LINUX_BUILD_URL ?= https://download.splunk.com/products/universalforwarder/releases/${SPLUNK_VERSION}/linux/${UF_LINUX_FILENAME}
+UF_LINUX_FILENAME ?= splunkforwarder-${SPLUNK_UF_VERSION}-${SPLUNK_UF_BUILD}-Linux-${SPLUNK_ARCH}.tgz
+UF_LINUX_BUILD_URL ?= https://download.splunk.com/products/universalforwarder/releases/${SPLUNK_UF_VERSION}/linux/${UF_LINUX_FILENAME}
 # Windows Splunk arguments
 SPLUNK_WIN_FILENAME ?= splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-x64-release.msi
 SPLUNK_WIN_BUILD_URL ?= https://download.splunk.com/products/${SPLUNK_PRODUCT}/releases/${SPLUNK_VERSION}/windows/${SPLUNK_WIN_FILENAME}
-UF_WIN_FILENAME ?= splunkforwarder-${SPLUNK_VERSION}-${SPLUNK_BUILD}-x64-release.msi
-UF_WIN_BUILD_URL ?= https://download.splunk.com/products/universalforwarder/releases/${SPLUNK_VERSION}/windows/${UF_WIN_FILENAME}
+UF_WIN_FILENAME ?= splunkforwarder-${SPLUNK_UF_VERSION}-${SPLUNK_UF_BUILD}-x64-release.msi
+UF_WIN_BUILD_URL ?= https://download.splunk.com/products/universalforwarder/releases/${SPLUNK_UF_VERSION}/windows/${UF_WIN_FILENAME}
 # Splunk Cloud SDK binary
 SCLOUD_URL ?= https://github.com/splunk/splunk-cloud-sdk-go/releases/download/v1.11.1/scloud_v7.1.0_linux_amd64.tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ SPLUNK_ANSIBLE_BRANCH ?= develop
 SPLUNK_COMPOSE ?= cluster_absolute_unit.yaml
 # Set Splunk version/build parameters here to define downstream URLs and file names
 SPLUNK_PRODUCT := splunk
-SPLUNK_VERSION := 8.2.3
-SPLUNK_BUILD := cd0848707637
+SPLUNK_VERSION := 8.2.3.2
+SPLUNK_BUILD := 5281ae34c90c
 ifeq ($(shell arch), s390x)
 	SPLUNK_ARCH = s390x
 else

--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -31,7 +31,7 @@ microdnf -y --nodocs install wget sudo shadow-utils procps tar make gcc \
 # Patch security updates
 microdnf -y --nodocs update gnutls kernel-headers librepo libnghttp2 nettle \
                             libpwquality libxml2 systemd-libs glib2 lz4-libs \
-                            rpm rpm-libs
+                            rpm rpm-libs sqlite-libs
 
 # Reinstall tzdata (originally stripped from minimal image): https://bugzilla.redhat.com/show_bug.cgi?id=1903219
 microdnf -y --nodocs reinstall tzdata || microdnf -y --nodocs update tzdata

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,9 +10,14 @@ Red Hat images will continue to be published.
 
 ## Navigation
 
+* [8.2.3.2](#8232)
+* [8.2.3](#823)
 * [8.2.2](#822)
 * [8.2.1](#821)
 * [8.2.0](#820)
+* [8.1.7](#817)
+* [8.1.7.1](#8171)
+* [8.1.6](#816)
 * [8.1.5](#815)
 * [8.1.4](#814)
 * [8.1.3](#813)
@@ -59,6 +64,13 @@ Red Hat images will continue to be published.
 * [7.2.2](#722)
 * [7.2.1](#721)
 * [7.2.0](#720)
+
+---
+
+## 8.2.3.2
+
+#### What's New?
+* New Splunk Enterprise security patch. For details, see [Fixed issues for 8.2.3.2](https://docs.splunk.com/Documentation/Splunk/8.2.3/ReleaseNotes/Fixedissues)
 
 ---
 
@@ -118,6 +130,39 @@ Red Hat images will continue to be published.
 * Added support for setting `clientName` in `deploymentclient.conf`
     * `splunk.deployment_client.name` in `default.yml`
     * `SPLUNK_DEPLOYMENT_CLIENT_NAME` environment variable
+
+---
+
+## 8.1.7.1
+
+#### What's New?
+* New Splunk Enterprise security patch. For details, see [Fixed issues for 8.1.7](https://docs.splunk.com/Documentation/Splunk/8.1.7/ReleaseNotes/Fixedissues)
+* Bundling in changes to be consistent with the release of [8.2.3.2](#8232)
+
+#### Changes
+* See [8.2.3.2](#8232) changes
+
+---
+
+## 8.1.7
+
+#### What's New?
+* New Splunk Enterprise maintenance patch. For details, see [Fixed issues for 8.1.7](https://docs.splunk.com/Documentation/Splunk/8.1.7/ReleaseNotes/Fixedissues)
+* Bundling in changes to be consistent with the release of [8.2.3](#823)
+
+#### Changes
+* See [8.2.3](#823) changes
+
+---
+
+## 8.1.6
+
+#### What's New?
+* New Splunk Enterprise maintenance patch. For details, see [Fixed issues for 8.1.6](https://docs.splunk.com/Documentation/Splunk/8.1.6/ReleaseNotes/Fixedissues)
+* Bundling in changes to be consistent with the release of [8.2.2](#822)
+
+#### Changes
+* See [8.2.2](#822) changes
 
 ---
 


### PR DESCRIPTION
Security patch releases 8.2.3.2 and 8.1.7.1 for log4j remediation.

Added Makefile variable to differentiate SE and UF versions because 8.2.3.2 patch doesn't exist for UF (not affected).

Security patches:
* [CVE-2019-5827](https://access.redhat.com/security/cve/cve-2019-5827)