### PR TITLE
Updated checkstate to support healthcheck disabling via file

### DIFF
--- a/splunk/common-files/checkstate.sh
+++ b/splunk/common-files/checkstate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Splunk
+# Copyright 2023 Splunk
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,20 +15,25 @@
 # limitations under the License.
 #
 
-#This script is used to retrieve and report the state of the container
-#Although not actively in the container, it can be used to check the health
-#of the splunk instance
-#NOTE: If you plan on running the splunk container while keeping Splunk
+# This script is used to retrieve and report the state of the container
+# Although not actively in the container, it can be used to check the health
+# of the splunk instance
+# NOTE: If you plan on running the splunk container while keeping Splunk
 # inactive for long periods of time, this script may give misleading
 # health results
 
-if [[ "" == "$NO_HEALTHCHECK" ]]; then
-    if [[ "false" == "$SPLUNKD_SSL_ENABLE" || "false" == "$(/opt/splunk/bin/splunk btool server list | grep enableSplunkdSSL | cut -d\  -f 3)" ]]; then
+# It is possible to disable the healthcheck utlizing one of the following methods:
+# Set the NO_HEALTHCHECK variable
+# Create the file "/tmp/healthcheck-disabled"
+
+if [[ "" == "$NO_HEALTHCHECK" ]] && [[ ! -f /tmp/healthcheck-disabled ]]; then
+	
+	if [[ "false" == "$SPLUNKD_SSL_ENABLE" || "false" == "$(/opt/splunk/bin/splunk btool server list | grep enableSplunkdSSL | cut -d\  -f 3)" ]]; then
       SCHEME="http"
 	else
       SCHEME="https"
     fi
-	#If NO_HEALTHCHECK is NOT defined, then we want the healthcheck
+
 	state="$(< $CONTAINER_ARTIFACT_DIR/splunk-container.state)"
 
 	case "$state" in
@@ -40,6 +45,5 @@ if [[ "" == "$NO_HEALTHCHECK" ]]; then
 	    exit 1
 	esac
 else
-	#If NO_HEALTHCHECK is defined, ignore the healthcheck
 	exit 0
 fi


### PR DESCRIPTION
Dear maintainers,

in usual environments that run the `checkstate.sh` (like Kubernetes) containers are immutable.
That means that you cannot simply inject an env variable into the container without restarting the actual container.

However, due to the nature of Splunk it might be needed to perform some maintenance tasks that require a `splunkd stop`.
This means you need to restart the container first to add the env variable,do your thing and afterwards you need to restart the container again to remove the env variable. So in this case the healthcheck actually decreases availability.

Therefore I would kindly request to add a file check as well. That way you can disable the healthcheck in a running container temporary by creating the file and with out any additional container restarts.
Indeed the env variable method is also an option - nothing changes there.

Pleas consider merging or let me know if you need any additional changes!