### PR TITLE
Resolve issue "make base-debian-10 failing"

### DIFF
--- a/base/debian-10/install.sh
+++ b/base/debian-10/install.sh
@@ -30,6 +30,8 @@ ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 /usr/sbin/dpkg-reconfigure -f noninteractive tzdata
 
 # Install utility packages
+# it is presently unknown why some packages are installed at latest versions (example: gcc)
+# whereas other packages are installed at specific versions (example: libgnutls30=3.6.7-4+deb10u10)
 apt-get install -y --no-install-recommends curl sudo libgssapi-krb5-2 busybox procps acl gcc make \
                                            libffi-dev libssl-dev make build-essential libbz2-dev \
                                            wget xz-utils ca-certificates zlib1g-dev python3-apt p11-kit liblz4-dev \

--- a/base/debian-10/install.sh
+++ b/base/debian-10/install.sh
@@ -33,7 +33,7 @@ ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 apt-get install -y --no-install-recommends curl sudo libgssapi-krb5-2 busybox procps acl gcc make \
                                            libffi-dev libssl-dev make build-essential libbz2-dev \
                                            wget xz-utils ca-certificates zlib1g-dev python3-apt p11-kit liblz4-dev \
-                                           libhogweed4=3.4.1-1+deb10u1 libgnutls30=3.6.7-4+deb10u7 libgcrypt20=1.8.4-5+deb10u1
+                                           libhogweed4=3.4.1-1+deb10u1 libgnutls30=3.6.7-4+deb10u10 libgcrypt20=1.8.4-5+deb10u1
 
 # Install Python and necessary packages
 PY_SHORT=${PYTHON_VERSION%.*}


### PR DESCRIPTION
Currently it is not possible to perform the following:

1. Checkout the splunk repo.
2. Run the following: `make base-debian-10`

While the existing repo indicates "We are no longer releasing Debian images on Docker Hub as of May 2021 (Splunk Enterprise v8.2.0+). Red Hat images will continue to be published" the files for building images based on debian are still there which may cause some confusion as to "maintained Dockerfiles" and "published images".

I feel that supporting Debian (or at least two flavors of Linux) would be ideal so I've gone ahead and updated the file so `make base-debian-10` runs correctly.

I've also added a comment regarding the use of specific versions of software during builds - I feel that it is important to note why specific versions are being used - either as a philosophy (i.e. we want predictability in builds) or as a software requirement.