### PR TITLE
install busybox 1.36.1 in base redhat 8

### DIFF
--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -28,7 +28,8 @@ export LANG=en_US.utf8
 # Install utility packages
 microdnf -y --nodocs install wget sudo shadow-utils procps tar make gcc \
                              openssl-devel bzip2-devel libffi-devel findutils \
-                             libssh-devel libcurl-devel glib2-devel ncurses-devel
+                             libssh-devel libcurl-devel glib2-devel ncurses-devel \
+                             diffutils bzip2
 # Patch security updates
 microdnf -y --nodocs update gnutls kernel-headers libdnf librepo libnghttp2 nettle \
                             libpwquality libxml2 systemd-libs lz4-libs curl \
@@ -38,6 +39,18 @@ microdnf -y --nodocs update gnutls kernel-headers libdnf librepo libnghttp2 nett
 
 # Reinstall tzdata (originally stripped from minimal image): https://bugzilla.redhat.com/show_bug.cgi?id=1903219
 microdnf -y --nodocs reinstall tzdata || microdnf -y --nodocs update tzdata
+
+# Build and install busybox direct from the multiarch since EPEL isn't available yet for redhat8
+cd ~
+wget https://busybox.net/downloads/busybox-1.36.1.tar.bz2
+bzip2 -d busybox-1.36.1.tar.bz2
+tar -xf busybox-1.36.1.tar
+cd busybox-1.36.1
+make defconfig
+make
+cp busybox /bin/busybox
+cd ~
+rm -rf busybox-1.36.1.tar busybox-1.36.1/
 
 # Install Python and necessary packages
 PY_SHORT=${PYTHON_VERSION%.*}
@@ -74,13 +87,8 @@ ldconfig
 microdnf remove -y make gcc openssl-devel bzip2-devel findutils glib2-devel glibc-devel cpp binutils \
                    keyutils-libs-devel krb5-devel libcom_err-devel libffi-devel libcurl-devel \
                    libselinux-devel libsepol-devel libssh-devel libverto-devel libxcrypt-devel \
-                   ncurses-devel pcre2-devel zlib-devel
+                   ncurses-devel pcre2-devel zlib-devel diffutils bzip2
 microdnf clean all
-
-# Install busybox direct from the multiarch since EPEL isn't available yet for redhat8
-BUSYBOX_URL=${BUSYBOX_URL:=https://busybox.net/downloads/binaries/1.35.0-`arch`-linux-musl/busybox}
-wget -O /bin/busybox ${BUSYBOX_URL}
-chmod +x /bin/busybox
 
 # Enable busybox symlinks
 cd /bin

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Red Hat images will continue to be published.
 * [9.2.0.1](#9201)
 * [9.2.0](#920)
 * [9.1.4](#914)
+* [9.1.3-patch1](#913p1)
 * [9.1.3](#913)
 * [9.1.2](#912)
 * [9.1.1](#911)
@@ -152,6 +153,20 @@ Red Hat images will continue to be published.
 
 #### docker-splunk changes:
 * Bumping Splunk version. For details, see [Fixed issues for 9.1.4](https://docs.splunk.com/Documentation/Splunk/9.1.4/ReleaseNotes/Fixedissues#Splunk_Enterprise_9.1.4)
+
+#### splunk-ansible changes:
+* Docs updated
+* Bugfixes
+
+---
+
+## 9.1.3-patch1
+
+#### What's New?
+* Install busybox 1.36.1 for remediation of CVE-2022-28391 and CVE-2022-30065
+
+#### docker-splunk changes:
+* Bumping Splunk version. For details, see [Fixed issues for 9.1.3](https://docs.splunk.com/Documentation/Splunk/9.1.3/ReleaseNotes/Fixedissues#Splunk_Enterprise_9.1.3)
 
 #### splunk-ansible changes:
 * Docs updated


### PR DESCRIPTION
Update busybox to 1.36.1 to remediate the following CVE:
* CVE-2022-28391
* CVE-2022-30065