### PR TITLE
Deprecate unused BUSYBOX_URL variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ base-redhat-8:
 	docker build ${DOCKER_BUILD_FLAGS} --label version=${SPLUNK_VERSION} -t base-redhat-8:${IMAGE_VERSION} ./base/redhat-8
 
 base-redhat-8-armv8:
-	docker buildx build ${DOCKER_BUILD_FLAGS} --build-arg BUSYBOX_URL=${BUSYBOX_URL} --label version=${SPLUNK_VERSION} -t base-redhat-8-armv8:${IMAGE_VERSION} ./base/redhat-8
+	docker buildx build ${DOCKER_BUILD_FLAGS} --label version=${SPLUNK_VERSION} -t base-redhat-8-armv8:${IMAGE_VERSION} ./base/redhat-8
 
 base-windows-2016:
 	docker build ${DOCKER_BUILD_FLAGS} -t base-windows-2016:${IMAGE_VERSION} ./base/windows-2016

--- a/base/redhat-8/Dockerfile
+++ b/base/redhat-8/Dockerfile
@@ -25,10 +25,7 @@ LABEL name="splunk" \
       summary="UBI 8 Docker image of Splunk Enterprise" \
       description="Splunk Enterprise is a platform for operational intelligence. Our software lets you collect, analyze, and act upon the untapped value of big data that your technology infrastructure, security systems, and business applications generate. It gives you insights to drive operational performance and business results."
 
-ARG BUSYBOX_URL
-
-ENV BUSYBOX_URL=${BUSYBOX_URL} \
-    PYTHON_VERSION=3.7.16 \
+ENV PYTHON_VERSION=3.7.16 \
     PYTHON_GPG_KEY_ID=0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 
 COPY install.sh /install.sh


### PR DESCRIPTION
As of the most recent commit, 0de4bffe24c71604a19d95222011d1b2e6d41f10, I can see that the URL to download Busybox into the RHEL 8 UBI container is being hard-coded into the `install.sh` script:

https://github.com/splunk/docker-splunk/blob/0de4bffe24c71604a19d95222011d1b2e6d41f10/base/redhat-8/install.sh#L45

This seems to deprecate the previous lines:
https://github.com/splunk/docker-splunk/blob/07a7c86f15abd13a1ee97661bdf8e4e762f8d1bf/base/redhat-8/install.sh#L81-L83

It seems like this was mainly being used in the Makefile for the armv8 RHEL8 container, passed in as a build-arg, which overrode the default:
https://github.com/splunk/docker-splunk/blob/0de4bffe24c71604a19d95222011d1b2e6d41f10/Makefile#L77-L78

I guess this needed overriding for the armv8 container since Busybox don't seem to publish `aarch64` builds at that URL above.

But now, as of 0de4bffe24c71604a19d95222011d1b2e6d41f10,  we're building from source and not actually using the `$BUSYBOX_URL` variable anywhere, this is having no effect even if we do pass it in as a build-arg. So for clarity, we might as well remove the variable entirely.