### PR TITLE
Update exclude list for changes in splunk files

### DIFF
--- a/splunk/common-files/make-minimal-exclude.py
+++ b/splunk/common-files/make-minimal-exclude.py
@@ -39,7 +39,6 @@ if version_string:
     minor_version = version_string.group(2)
 
 if major_version:
-    print(EXCLUDE_V7)
     if int(major_version) == 7:
         print("*/bin/parsetest*")
         if int(minor_version) < 3:
@@ -51,3 +50,7 @@ if major_version:
         print("*/etc/apps/splunk_metrics_workspace*")
         if int(minor_version) < 1:
             print("*/bin/parsetest*")
+    elif int(major_version) == 9:
+        if int(minor_version) >= 4:
+            EXCLUDE_V7 = EXCLUDE_V7.replace('*/bin/jsmin*', '')
+    print(EXCLUDE_V7)

--- a/splunk/common-files/make-minimal-exclude.py
+++ b/splunk/common-files/make-minimal-exclude.py
@@ -50,7 +50,7 @@ if major_version:
         print("*/etc/apps/splunk_metrics_workspace*")
         if int(minor_version) < 1:
             print("*/bin/parsetest*")
-    elif int(major_version) == 9:
+    elif int(major_version) >= 9:
         if int(minor_version) >= 4:
             EXCLUDE_V7 = EXCLUDE_V7.replace('*/bin/jsmin*', '')
     print(EXCLUDE_V7)


### PR DESCRIPTION
The splunk/bin/jsmin folder path is no longer packaged tentatively as of the 9.4 version.  Tar with --files-from will fail as this path is one of the patterns to search for.   Since tar doesn't have a proper ignore error flag for this type of extraction, update the minimal exclude script to remove this path pattern for this version and beyond.
