### PR TITLE
fix(logging): handle file rotation of splunkd_sterr.log

### DIFF
--- a/splunk/common-files/entrypoint.sh
+++ b/splunk/common-files/entrypoint.sh
@@ -62,10 +62,10 @@ watch_for_failure(){
 	# Any crashes/errors while Splunk is running should get logged to splunkd_stderr.log and sent to the container's stdout
 	if [ -z "$SPLUNK_TAIL_FILE" ]; then
 		echo Ansible playbook complete, will begin streaming splunkd_stderr.log
-		${RUN_AS_SPLUNK} tail -n 0 -f ${SPLUNK_HOME}/var/log/splunk/splunkd_stderr.log &
+		${RUN_AS_SPLUNK} tail -n 0 -F ${SPLUNK_HOME}/var/log/splunk/splunkd_stderr.log &
 	else
 		echo Ansible playbook complete, will begin streaming ${SPLUNK_TAIL_FILE}
-		${RUN_AS_SPLUNK} tail -n 0 -f ${SPLUNK_TAIL_FILE} &
+		${RUN_AS_SPLUNK} tail -n 0 -F ${SPLUNK_TAIL_FILE} &
 	fi
 	if [[ "$DISABLE_ENTIRE_SHELL_ACCESS" == "true" ]]; then
 		disable_entire_shell_access_for_container

--- a/uf/common-files/entrypoint.sh
+++ b/uf/common-files/entrypoint.sh
@@ -63,9 +63,9 @@ watch_for_failure(){
 	fi
 	# Any crashes/errors while Splunk is running should get logged to splunkd_stderr.log and sent to the container's stdout
 	if [ -z "$SPLUNK_TAIL_FILE" ]; then
-		${RUN_AS_SPLUNK} tail -n 0 -f ${SPLUNK_HOME}/var/log/splunk/splunkd_stderr.log &
+		${RUN_AS_SPLUNK} tail -n 0 -F ${SPLUNK_HOME}/var/log/splunk/splunkd_stderr.log &
 	else
-		${RUN_AS_SPLUNK} tail -n 0 -f ${SPLUNK_TAIL_FILE} &
+		${RUN_AS_SPLUNK} tail -n 0 -F ${SPLUNK_TAIL_FILE} &
 	fi
 	wait
 }


### PR DESCRIPTION
Fix issue with logging of standard error messages where standard error logs would be lost when logging large amount of data to stadard error.

Splunk logs to splunkd_stdout.log as the Unix standard error device. This file is rotated. According to [What Splunk software logs about itself](https://docs.splunk.com/Documentation/Splunk/9.2.1/Troubleshooting/WhatSplunklogsaboutitself), "The historical rotation for most internal logs is 5 files of 25MB each".

docker-splunk container tails the output of splunkd_stdout.log to standard output. The existing behavior is that the container receives Splunk's standard error messages until splunkd_stdout.log is about 25MB. When the log files passes 25MB, Splunk rotates the log file by rename splunkd_stdout.log to something like splunkd_stoudt1.log and creating a new splunkd_stdout.log.

By default, tail follows the file descriptor of argument file. I believe that if the file is renamed, it continutes to track the file descriptor of argument file, if that is available. This is not the behavior we want for file rotation, since we always want to follow the information that goes to splunkd_stdout.log and not splunkd_stdout1.log, splunkd_stdout2.log, etc.

Fix standard error logs not surfacing by passing `-F` option to unix tail command. This causes tail to keep retrying to open argument file name if it becomes unavailable.

Change in behavior to print standard error logs to standard out for entire lifetime of the program, instead of stopping after the first file rotation.

Fix #626