### PR TITLE
add redhat 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ base-redhat-8:
 base-redhat-8-armv8:
 	docker buildx build ${DOCKER_BUILD_FLAGS} --build-arg BUSYBOX_URL=${BUSYBOX_URL} --label version=${SPLUNK_VERSION} -t base-redhat-8-armv8:${IMAGE_VERSION} ./base/redhat-8
 
+base-redhat-9:
+	docker build ${DOCKER_BUILD_FLAGS} --label version=${SPLUNK_VERSION} -t base-redhat-9:${IMAGE_VERSION} ./base/redhat-9
+
 base-windows-2016:
 	docker build ${DOCKER_BUILD_FLAGS} -t base-windows-2016:${IMAGE_VERSION} ./base/windows-2016
 
@@ -157,7 +160,7 @@ bare-redhat-8: base-redhat-8
 		--target bare -t bare-redhat-8:${IMAGE_VERSION} .
 
 ##### Splunk images #####
-splunk: ansible splunk-debian-9 splunk-debian-10 splunk-centos-7 splunk-centos-8 splunk-redhat-8
+splunk: ansible splunk-debian-9 splunk-debian-10 splunk-centos-7 splunk-centos-8 splunk-redhat-8 splunk-redhat-9
 
 splunk-debian-9: base-debian-9 ansible
 	docker build ${DOCKER_BUILD_FLAGS} \
@@ -194,6 +197,13 @@ splunk-redhat-8: base-redhat-8 ansible
 		--build-arg SPLUNK_BUILD_URL=${SPLUNK_LINUX_BUILD_URL} \
 		-t splunk-redhat-8:${IMAGE_VERSION} .
 
+splunk-redhat-9: base-redhat-9 ansible
+	docker build ${DOCKER_BUILD_FLAGS} \
+		-f splunk/common-files/Dockerfile \
+		--build-arg SPLUNK_BASE_IMAGE=base-redhat-9 \
+		--build-arg SPLUNK_BUILD_URL=${SPLUNK_LINUX_BUILD_URL} \
+		-t splunk-redhat-9:${IMAGE_VERSION} .
+
 splunk-windows-2016: base-windows-2016 ansible
 	docker build ${DOCKER_BUILD_FLAGS} \
 		-f splunk/windows-2016/Dockerfile \
@@ -202,7 +212,7 @@ splunk-windows-2016: base-windows-2016 ansible
 		-t splunk-windows-2016:${IMAGE_VERSION} .
 
 ##### UF images #####
-uf: ansible uf-debian-9 uf-debian-10 uf-centos-7 uf-centos-8 uf-redhat-8
+uf: ansible uf-debian-9 uf-debian-10 uf-centos-7 uf-centos-8 uf-redhat-8 uf-redhat-9
 
 ufbare-debian-9: base-debian-9 ansible
 	docker build ${DOCKER_BUILD_FLAGS} \
@@ -260,6 +270,12 @@ uf-redhat-8-armv8: base-redhat-8-armv8 ansible
 		--build-arg SPLUNK_BUILD_URL=${UF_LINUX_BUILD_URL} \
 		-t uf-redhat-8-armv8:${IMAGE_VERSION} .
 
+uf-redhat-9: base-redhat-9 ansible
+	docker build ${DOCKER_BUILD_FLAGS} \
+		-f uf/common-files/Dockerfile \
+		--build-arg SPLUNK_BASE_IMAGE=base-redhat-9 \
+		--build-arg SPLUNK_BUILD_URL=${UF_LINUX_BUILD_URL} \
+		-t uf-redhat-9:${IMAGE_VERSION} .
 
 uf-windows-2016: base-windows-2016 ansible
 	docker build ${DOCKER_BUILD_FLAGS} \

--- a/base/redhat-9/Dockerfile
+++ b/base/redhat-9/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2018-2021 Splunk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE that since OpenShift Container Platform 3.11
+# the container catalog moved from registry.access.redhat.com to registry.redhat.io
+# So at some point before they deprecate the old registry we have to make sure that
+# we have access to the new registry and change where we pull the ubi image from.
+FROM registry.access.redhat.com/ubi9/ubi-minimal
+
+LABEL name="splunk" \
+      maintainer="support@splunk.com" \
+      vendor="splunk" \
+      release="1" \
+      summary="UBI 9 Docker image of Splunk Enterprise" \
+      description="Splunk Enterprise is a platform for operational intelligence. Our software lets you collect, analyze, and act upon the untapped value of big data that your technology infrastructure, security systems, and business applications generate. It gives you insights to drive operational performance and business results."
+
+ARG BUSYBOX_URL
+
+ENV BUSYBOX_URL=${BUSYBOX_URL} \
+    PYTHON_VERSION=3.9.19 \
+    PYTHON_GPG_KEY_ID=E3FF2839C048B25C084DEBE9B26995E310250568
+
+COPY install.sh /install.sh
+
+RUN mkdir /licenses \
+    && curl -o /licenses/apache-2.0.txt https://www.apache.org/licenses/LICENSE-2.0.txt \
+    && curl -o /licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf \
+    && /install.sh && rm -rf /install.sh

--- a/base/redhat-9/install.sh
+++ b/base/redhat-9/install.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Copyright 2018-2021 Splunk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Generate UTF-8 char map and locale
+# Reinstalling local English def for now, removed in minimal image: https://bugzilla.redhat.com/show_bug.cgi?id=1665251
+# Comment below install until glibc update is available in minimal image: https://access.redhat.com/errata/RHSA-2024:2722
+#microdnf -y --nodocs install glibc-langpack-en
+
+# Currently there is no access to the UTF-8 char map. The following command is commented out until
+# the base container can generate the locale.
+# localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+# We get around the gen above by forcing the language install, and then pointing to it.
+export LANG=en_US.utf8
+
+# Install utility packages
+microdnf -y --nodocs install wget sudo shadow-utils procps tar make gcc \
+                             openssl-devel libffi-devel findutils libssh-devel \
+                             libcurl-devel glib2-devel ncurses-devel diffutils
+# Patch security updates
+microdnf -y --nodocs update gnutls kernel-headers libdnf librepo libnghttp2 nettle \
+                            libpwquality libxml2 systemd-libs lz4-libs curl \
+                            rpm rpm-libs sqlite-libs cyrus-sasl-lib vim expat \
+                            openssl-libs xz-libs zlib libsolv file-libs pcre \
+                            libarchive libgcrypt libksba libstdc++ json-c gnupg
+
+# TODO: install busybox via EPEL? Will this even work?
+# currently seeing errors when installing/building via source
+
+# Install Python and necessary packages
+PY_SHORT=${PYTHON_VERSION%.*}
+wget -O /tmp/python.tgz https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+wget -O /tmp/Python-gpg-sig-${PYTHON_VERSION}.tgz.asc https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz.asc
+gpg --keyserver keys.openpgp.org --recv-keys $PYTHON_GPG_KEY_ID \
+    || gpg --keyserver pool.sks-keyservers.net --recv-keys $PYTHON_GPG_KEY_ID \
+    || gpg --keyserver pgp.mit.edu --recv-keys $PYTHON_GPG_KEY_ID \
+    || gpg --keyserver keyserver.pgp.com --recv-keys $PYTHON_GPG_KEY_ID
+gpg --verify /tmp/Python-gpg-sig-${PYTHON_VERSION}.tgz.asc /tmp/python.tgz
+rm /tmp/Python-gpg-sig-${PYTHON_VERSION}.tgz.asc
+mkdir -p /tmp/pyinstall
+tar -xzC /tmp/pyinstall/ --strip-components=1 -f /tmp/python.tgz
+rm /tmp/python.tgz
+cd /tmp/pyinstall
+./configure --enable-optimizations --prefix=/usr --with-ensurepip=install
+make altinstall LDFLAGS="-Wl,--strip-all"
+rm -rf /tmp/pyinstall
+ln -sf /usr/bin/python${PY_SHORT} /usr/bin/python
+ln -sf /usr/bin/pip${PY_SHORT} /usr/bin/pip
+ln -sf /usr/bin/python${PY_SHORT} /usr/bin/python3
+ln -sf /usr/bin/pip${PY_SHORT} /usr/bin/pip3
+
+# Install splunk-ansible dependencies
+cd /
+/usr/bin/python3.9 -m pip install --upgrade pip
+pip -q --no-cache-dir install --upgrade "requests_unixsocket<2.29" "requests<2.29" six wheel Mako "urllib3<2.0.0" certifi jmespath future avro cryptography lxml protobuf setuptools ansible
+
+# Remove tests packaged in python libs
+find /usr/lib/ -depth \( -type d -a -not -wholename '*/ansible/plugins/test' -a \( -name test -o -name tests -o -name idle_test \) \) -exec rm -rf '{}' \;
+find /usr/lib/ -depth \( -type f -a -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) -exec rm -rf '{}' \;
+find /usr/lib/ -depth \( -type f -a -name 'wininst-*.exe' \) -exec rm -rf '{}' \;
+ldconfig
+
+# Cleanup
+microdnf remove -y make gcc openssl-devel findutils glib2-devel glibc-devel cpp \
+                   libffi-devel libcurl-devel libssh-devel libxcrypt-devel \
+                   ncurses-devel zlib-devel
+microdnf clean all
+
+# Enable busybox symlinks
+cd /bin
+BBOX_LINKS=( clear find diff hostname killall netstat nslookup ping ping6 readline route syslogd tail traceroute vi )
+for item in "${BBOX_LINKS[@]}"
+do
+  ln -s busybox $item || true
+done
+groupadd sudo
+
+echo "
+## Allows people in group sudo to run all commands
+%sudo  ALL=(ALL)       ALL" >> /etc/sudoers
+
+# Clean
+microdnf clean all
+rm -rf /install.sh /anaconda-post.log /var/log/anaconda/*

--- a/base/redhat-9/install.sh
+++ b/base/redhat-9/install.sh
@@ -29,7 +29,7 @@ export LANG=en_US.utf8
 # Install utility packages
 microdnf -y --nodocs install wget sudo shadow-utils procps tar make gcc \
                              openssl-devel libffi-devel findutils libssh-devel \
-                             libcurl-devel ncurses-devel diffutils
+                             libcurl-devel ncurses-devel diffutils zlib-devel
 # Patch security updates
 microdnf -y --nodocs update gnutls kernel-headers libdnf librepo libnghttp2 nettle \
                             libpwquality libxml2 systemd-libs lz4-libs curl \

--- a/base/redhat-9/install.sh
+++ b/base/redhat-9/install.sh
@@ -29,7 +29,7 @@ export LANG=en_US.utf8
 # Install utility packages
 microdnf -y --nodocs install wget sudo shadow-utils procps tar make gcc \
                              openssl-devel libffi-devel findutils libssh-devel \
-                             libcurl-devel glib2-devel ncurses-devel diffutils
+                             libcurl-devel ncurses-devel diffutils
 # Patch security updates
 microdnf -y --nodocs update gnutls kernel-headers libdnf librepo libnghttp2 nettle \
                             libpwquality libxml2 systemd-libs lz4-libs curl \
@@ -65,7 +65,7 @@ ln -sf /usr/bin/pip${PY_SHORT} /usr/bin/pip3
 # Install splunk-ansible dependencies
 cd /
 /usr/bin/python3.9 -m pip install --upgrade pip
-pip -q --no-cache-dir install --upgrade "requests_unixsocket<2.29" "requests<2.29" six wheel Mako "urllib3<2.0.0" certifi jmespath future avro cryptography lxml protobuf setuptools ansible
+pip -q --no-cache-dir install --upgrade requests_unixsocket requests six wheel Mako "urllib3<2.0.0" certifi jmespath future avro cryptography lxml protobuf setuptools ansible
 
 # Remove tests packaged in python libs
 find /usr/lib/ -depth \( -type d -a -not -wholename '*/ansible/plugins/test' -a \( -name test -o -name tests -o -name idle_test \) \) -exec rm -rf '{}' \;
@@ -74,7 +74,7 @@ find /usr/lib/ -depth \( -type f -a -name 'wininst-*.exe' \) -exec rm -rf '{}' \
 ldconfig
 
 # Cleanup
-microdnf remove -y make gcc openssl-devel findutils glib2-devel glibc-devel cpp \
+microdnf remove -y make gcc openssl-devel findutils glibc-devel cpp \
                    libffi-devel libcurl-devel libssh-devel libxcrypt-devel \
                    ncurses-devel zlib-devel
 microdnf clean all


### PR DESCRIPTION
Based off redhat 8 provision scripts with one notable change:
- **removes busybox installation**: RHEL 9 busybox installations require EPEL setup. Busybox is not required for a working image, and we do not want to expose any RHEL subscription credentials.

- [x]  **_Do before merging_**: finish scans for new vulnerabilities