### PR TITLE
Fix version regex for 9.4.0+

### DIFF
--- a/splunk/common-files/make-minimal-exclude.py
+++ b/splunk/common-files/make-minimal-exclude.py
@@ -30,7 +30,7 @@ EXCLUDE_V7 = """*-manifest
 */share/splunk/pdf*
 *mrsparkle*"""
 
-version_string = re.match(".*splunk-([0-9]+)\.([0-9]+)\.[0-9]+\.?[0-9]?-[0-9a-z]+-Linux-[0-9a-z_-]+.tgz", sys.argv[1])
+version_string = re.match(".*splunk-([0-9]+)\.([0-9]+)\.[0-9]+\.?[0-9]?-[0-9a-z]+-[lL]inux-[0-9a-z_-]+.tgz", sys.argv[1])
 major_version = None
 minor_version = None
 


### PR DESCRIPTION
Build naming was recently updated to handle changes in 9.4.0.

With this regex failing, the "minimal" and "extra" layers it's used to define were both the entire build. This fix should restore the original behavior and cut down the image size from ~8 GB -> ~3.5 GB