### PR TITLE
Splunk 10 version conditions

### DIFF
--- a/splunk/common-files/make-minimal-exclude.py
+++ b/splunk/common-files/make-minimal-exclude.py
@@ -46,11 +46,13 @@ if major_version:
             print("*/etc/apps/gettingstarted*")
         else:
             print("*/etc/apps/splunk_metrics_workspace*")
-    elif 7 < int(major_version) < 9:
+    elif int(major_version) == 8:
         print("*/etc/apps/splunk_metrics_workspace*")
         if int(minor_version) < 1:
             print("*/bin/parsetest*")
-    elif int(major_version) >= 9:
+    elif int(major_version) == 9:
         if int(minor_version) >= 4:
             EXCLUDE_V7 = EXCLUDE_V7.replace('*/bin/jsmin*', '')
+    elif int(major_version) > 9:
+        EXCLUDE_V7 = EXCLUDE_V7.replace('*/bin/jsmin*', '')
     print(EXCLUDE_V7)


### PR DESCRIPTION
Fixes exclude script for Splunk 10.0.0, removing `*/bin/jsmin*` from script output like we did for Splunk 9.4.0.