### PR TITLE
Remove busybox install

### DIFF
--- a/base/redhat-8/Dockerfile
+++ b/base/redhat-8/Dockerfile
@@ -23,7 +23,7 @@ LABEL name="splunk" \
       vendor="splunk" \
       release="1" \
       summary="UBI 8 Docker image of Splunk Enterprise" \
-      description="Splunk Enterprise is a platform for operational intelligence. Our software lets you collect, analyze, and act upon the untapped value of big data."
+      description="Splunk Enterprise is a platform for operational intelligence. Our software lets you collect, analyze, and act upon the untapped value of big data that your technology infrastructure, security systems, and business applications generate. It gives you insights to drive operational performance and business results."
 
 ENV PYTHON_VERSION=3.9.19 \
     PYTHON_GPG_KEY_ID=E3FF2839C048B25C084DEBE9B26995E310250568

--- a/base/redhat-8/Dockerfile
+++ b/base/redhat-8/Dockerfile
@@ -23,12 +23,9 @@ LABEL name="splunk" \
       vendor="splunk" \
       release="1" \
       summary="UBI 8 Docker image of Splunk Enterprise" \
-      description="Splunk Enterprise is a platform for operational intelligence. Our software lets you collect, analyze, and act upon the untapped value of big data that your technology infrastructure, security systems, and business applications generate. It gives you insights to drive operational performance and business results."
+      description="Splunk Enterprise is a platform for operational intelligence. Our software lets you collect, analyze, and act upon the untapped value of big data."
 
-ARG BUSYBOX_URL
-
-ENV BUSYBOX_URL=${BUSYBOX_URL} \
-    PYTHON_VERSION=3.9.19 \
+ENV PYTHON_VERSION=3.9.19 \
     PYTHON_GPG_KEY_ID=E3FF2839C048B25C084DEBE9B26995E310250568
 
 COPY install.sh /install.sh
@@ -36,4 +33,4 @@ COPY install.sh /install.sh
 RUN mkdir /licenses \
     && curl -o /licenses/apache-2.0.txt https://www.apache.org/licenses/LICENSE-2.0.txt \
     && curl -o /licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf \
-    && /install.sh && rm -rf /install.sh
+    && /install.sh

--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set -e
 
 # Generate UTF-8 char map and locale

--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -31,6 +31,7 @@ microdnf -y --nodocs install wget sudo shadow-utils procps tar make gcc \
                              openssl-devel bzip2-devel libffi-devel findutils \
                              libssh-devel libcurl-devel ncurses-devel \
                              diffutils bzip2
+                             
 # Patch security updates
 microdnf -y --nodocs update gnutls kernel-headers libdnf librepo libnghttp2 nettle \
                             libpwquality libxml2 systemd-libs lz4-libs curl \
@@ -40,18 +41,6 @@ microdnf -y --nodocs update gnutls kernel-headers libdnf librepo libnghttp2 nett
 
 # Reinstall tzdata (originally stripped from minimal image): https://bugzilla.redhat.com/show_bug.cgi?id=1903219
 microdnf -y --nodocs reinstall tzdata || microdnf -y --nodocs update tzdata
-
-# Build and install busybox direct from the multiarch since EPEL isn't available yet for redhat8
-cd ~
-wget https://busybox.net/downloads/busybox-1.36.1.tar.bz2
-bzip2 -d busybox-1.36.1.tar.bz2
-tar -xf busybox-1.36.1.tar
-cd busybox-1.36.1
-make defconfig
-make
-cp busybox /bin/busybox
-cd ~
-rm -rf busybox-1.36.1.tar busybox-1.36.1/
 
 # Install Python and necessary packages
 PY_SHORT=${PYTHON_VERSION%.*}
@@ -93,14 +82,6 @@ microdnf remove -y make gcc openssl-devel bzip2-devel findutils glibc-devel cpp 
                    ncurses-devel pcre2-devel zlib-devel diffutils bzip2
 microdnf clean all
 
-# Enable busybox symlinks
-cd /bin
-BBOX_LINKS=( clear find diff hostname killall netstat nslookup ping ping6 readline route syslogd tail traceroute vi )
-for item in "${BBOX_LINKS[@]}"
-do
-  ln -s busybox $item || true
-done
-chmod u+s /bin/ping
 groupadd sudo
 
 echo "

--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 set -e
 
 # Generate UTF-8 char map and locale


### PR DESCRIPTION
This update removes the installation and use of BusyBox from the RedHat8-based Splunk Docker image to reduce potential security vulnerabilities. The existing OS-level packages already provide the necessary shell utilities, making BusyBox redundant. This ensures a more secure and maintainable container environment while maintaining full functionality.