### PR TITLE
remove node files from minimal exclude in 10.1

### DIFF
--- a/splunk/common-files/make-minimal-exclude.py
+++ b/splunk/common-files/make-minimal-exclude.py
@@ -54,9 +54,10 @@ if major_version:
         if int(minor_version) >= 4:
             EXCLUDE_V7 = EXCLUDE_V7.replace('*/bin/jsmin*', '')
     elif int(major_version) == 10:
-        if int(minor_version) >= 2:
+        if int(minor_version) >= 1:
             EXCLUDE_V7 = EXCLUDE_V7.replace('*/bin/node*', '')
             EXCLUDE_V7 = EXCLUDE_V7.replace('*/lib/node_modules*', '')
+        if int(minor_version) >= 2:
             EXCLUDE_V7 = EXCLUDE_V7.replace('*/bin/jars/*', '')
             EXCLUDE_V7 = EXCLUDE_V7.replace('*/etc/apps/splunk_archiver*', '')
         EXCLUDE_V7 = EXCLUDE_V7.replace('*/bin/jsmin*', '')


### PR DESCRIPTION
Preliminary 10.1 builds show that the following file paths have been removed (similar to 10.2):
```
80.93 tar: */bin/node*: Not found in archive
80.93 tar: */lib/node_modules*: Not found in archive
```