### PR TITLE
Remove netbox ansible collection

### DIFF
--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -68,6 +68,7 @@ ln -sf /usr/bin/pip${PY_SHORT} /usr/bin/pip3
 cd /
 /usr/bin/python3.9 -m pip install --upgrade pip
 pip -q --no-cache-dir install --upgrade requests_unixsocket requests six wheel Mako "urllib3<2.0.0" certifi jmespath future avro cryptography lxml protobuf setuptools ansible
+rm -rf /usr/lib/python3.9/site-packages/ansible_collections/netbox/
 
 # Remove tests packaged in python libs
 find /usr/lib/ -depth \( -type d -a -not -wholename '*/ansible/plugins/test' -a \( -name test -o -name tests -o -name idle_test \) \) -exec rm -rf '{}' \;

--- a/base/redhat-9/install.sh
+++ b/base/redhat-9/install.sh
@@ -66,6 +66,7 @@ ln -sf /usr/bin/pip${PY_SHORT} /usr/bin/pip3
 cd /
 /usr/bin/python3.9 -m pip install --upgrade pip
 pip -q --no-cache-dir install --upgrade requests_unixsocket requests six wheel Mako urllib3 certifi jmespath future avro cryptography lxml protobuf setuptools ansible
+rm -rf /usr/lib/python3.9/site-packages/ansible_collections/netbox/
 
 # Remove tests packaged in python libs
 find /usr/lib/ -depth \( -type d -a -not -wholename '*/ansible/plugins/test' -a \( -name test -o -name tests -o -name idle_test \) \) -exec rm -rf '{}' \;


### PR DESCRIPTION
Resolves vulnerability CVE-2025-58367 reported by AWS Inspector. This ansible collection is not currently used by splunk-ansible.