### PR TITLE
Keep findutils installed pre 10.0

### DIFF
--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -77,7 +77,7 @@ find /usr/lib/ -depth \( -type f -a -name 'wininst-*.exe' \) -exec rm -rf '{}' \
 ldconfig
 
 # Cleanup
-microdnf remove -y make gcc openssl-devel bzip2-devel findutils glibc-devel cpp binutils \
+microdnf remove -y make gcc openssl-devel bzip2-devel glibc-devel cpp binutils \
                    keyutils-libs-devel krb5-devel libcom_err-devel libffi-devel libcurl-devel \
                    libselinux-devel libsepol-devel libssh-devel libverto-devel libxcrypt-devel \
                    ncurses-devel pcre2-devel zlib-devel diffutils bzip2 glibc-headers kernel-headers


### PR DESCRIPTION
Mirror of the change here: https://github.com/splunk/docker-splunk/pull/721

Ensure we don't remove `findutils` after installing it.